### PR TITLE
feat(console): add staff directory for security admins

### DIFF
--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -62,7 +62,11 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     );
   }
 
-  const navItems = buildNavItems(staffUser.permissions);
+  const navItems = [...buildNavItems(staffUser.permissions)];
+
+  if (staffUser.roles.includes('security_admin')) {
+    navItems.push({ href: '/staff', label: 'Staff' });
+  }
 
   return (
     <html lang="en" data-theme="torvus-staff">

--- a/apps/console/app/staff/[userId]/page.tsx
+++ b/apps/console/app/staff/[userId]/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import clsx from 'clsx';
+import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { RoleBadge } from '../../../components/RoleBadge';
+import { getStaffUser } from '../../../lib/auth';
+import { getCurrentStaffWithRoles, getStaffByIdWithRoles } from '../../../lib/data/staff';
+
+export const metadata: Metadata = {
+  title: 'Staff member | Torvus Console'
+};
+
+type StaffDetailPageProps = {
+  params: {
+    userId: string;
+  };
+};
+
+function PasskeyBadge({ enrolled }: { enrolled: boolean }) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        enrolled
+          ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200'
+          : 'border-slate-700/70 bg-slate-800/80 text-slate-400'
+      )}
+    >
+      {enrolled ? '✓ Passkey enrolled' : '—'}
+    </span>
+  );
+}
+
+export default async function StaffDetailPage({ params }: StaffDetailPageProps) {
+  const staffUser = await getStaffUser();
+
+  try {
+    const currentStaff = staffUser ? await getCurrentStaffWithRoles(staffUser.email) : null;
+
+    if (!currentStaff || !currentStaff.roles.includes('security_admin')) {
+      return (
+        <div className="flex flex-col items-center justify-center py-24">
+          <AccessDeniedNotice variant="card" />
+        </div>
+      );
+    }
+
+    const staffMember = await getStaffByIdWithRoles(params.userId);
+
+    if (!staffMember) {
+      return (
+        <div className="flex flex-col gap-6 py-12">
+          <div className="rounded-3xl border border-slate-700 bg-slate-900/60 p-8 text-center shadow-2xl">
+            <h1 className="text-2xl font-semibold text-slate-100">Staff member not found</h1>
+            <p className="mt-2 text-sm text-slate-400">The requested staff profile does not exist.</p>
+            <div className="mt-6">
+              <Link
+                href="/staff"
+                className="inline-flex items-center rounded-full border border-slate-700/70 px-4 py-1.5 text-sm font-medium text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-200"
+              >
+                Back to directory
+              </Link>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-6 py-6">
+        <Link
+          href="/staff"
+          className="self-start rounded-full border border-slate-700/70 px-4 py-1.5 text-sm font-medium text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-200"
+        >
+          ← Back to directory
+        </Link>
+        <section className="rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-3xl font-semibold text-slate-100">{staffMember.displayName}</h1>
+              <p className="text-sm text-slate-400">{staffMember.email}</p>
+              <PasskeyBadge enrolled={staffMember.passkeyEnrolled} />
+            </div>
+            <div className="flex flex-col gap-3">
+              <span className="text-xs uppercase tracking-wide text-slate-500">Roles</span>
+              <div className="flex flex-wrap gap-2">
+                {staffMember.roles.length ? (
+                  staffMember.roles.map((role) => <RoleBadge key={role} role={role} />)
+                ) : (
+                  <span className="text-xs text-slate-500">—</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load staff profile', error);
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+      </div>
+    );
+  }
+}

--- a/apps/console/app/staff/page.tsx
+++ b/apps/console/app/staff/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next';
+import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+import { StaffTable } from '../../components/StaffTable';
+import { getStaffUser } from '../../lib/auth';
+import { getAllStaffWithRoles, getCurrentStaffWithRoles } from '../../lib/data/staff';
+
+export const metadata: Metadata = {
+  title: 'Staff directory | Torvus Console'
+};
+
+const PAGE_SIZE = 25;
+
+type StaffPageProps = {
+  searchParams?: {
+    q?: string;
+    page?: string;
+  };
+};
+
+export default async function StaffPage({ searchParams }: StaffPageProps) {
+  const staffUser = await getStaffUser();
+
+  if (!staffUser) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+      </div>
+    );
+  }
+
+  const rawQuery = typeof searchParams?.q === 'string' ? searchParams.q : '';
+  const query = rawQuery.trim();
+  const pageParam = typeof searchParams?.page === 'string' ? Number.parseInt(searchParams.page, 10) : 1;
+  const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+  const offset = (page - 1) * PAGE_SIZE;
+
+  try {
+    const currentStaff = await getCurrentStaffWithRoles(staffUser.email);
+
+    if (!currentStaff || !currentStaff.roles.includes('security_admin')) {
+      return (
+        <div className="flex flex-col items-center justify-center py-24">
+          <AccessDeniedNotice variant="card" />
+        </div>
+      );
+    }
+
+    const { staff, count } = await getAllStaffWithRoles({ q: query, limit: PAGE_SIZE, offset });
+
+    return (
+      <div className="flex flex-col gap-8 py-6">
+        <StaffTable staff={staff} query={query} page={page} pageSize={PAGE_SIZE} totalCount={count} />
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load staff directory', error);
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+      </div>
+    );
+  }
+}

--- a/apps/console/components/StaffTable.tsx
+++ b/apps/console/components/StaffTable.tsx
@@ -1,0 +1,168 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+import { RoleBadge } from './RoleBadge';
+import type { StaffDirectoryEntry } from '../lib/data/staff';
+
+export type StaffTableProps = {
+  staff: StaffDirectoryEntry[];
+  query: string;
+  page: number;
+  pageSize: number;
+  totalCount: number;
+};
+
+function buildPageHref(page: number, query: string) {
+  const params = new URLSearchParams();
+  if (query) {
+    params.set('q', query);
+  }
+  if (page > 1) {
+    params.set('page', String(page));
+  }
+  const queryString = params.toString();
+  return `/staff${queryString ? `?${queryString}` : ''}`;
+}
+
+function PasskeyPill({ enrolled }: { enrolled: boolean }) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        enrolled
+          ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200'
+          : 'border-slate-700/70 bg-slate-800/80 text-slate-400'
+      )}
+    >
+      {enrolled ? '✓ Passkey' : '—'}
+    </span>
+  );
+}
+
+export function StaffTable({ staff, query, page, pageSize, totalCount }: StaffTableProps) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const from = totalCount === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = totalCount === 0 ? 0 : Math.min(page * pageSize, totalCount);
+
+  return (
+    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Staff directory</h1>
+          <p className="text-sm text-slate-400">
+            Review privileged Torvus staff accounts and their assigned roles.
+          </p>
+        </div>
+        <form method="get" className="w-full max-w-xs lg:w-auto">
+          <label className="flex w-full items-center gap-2 rounded-full border border-slate-700 bg-slate-950/60 px-4 py-2 text-sm text-slate-200 focus-within:border-slate-500">
+            <span className="sr-only">Search staff</span>
+            <input
+              type="search"
+              name="q"
+              defaultValue={query}
+              placeholder="Search staff"
+              className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+            />
+          </label>
+        </form>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-800/60">
+        <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm text-slate-200">
+          <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th scope="col" className="px-6 py-3">
+                Display name
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Email
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Roles
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Passkey
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {staff.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-12 text-center text-sm text-slate-400">
+                  No staff members match your search.
+                </td>
+              </tr>
+            ) : (
+              staff.map((member) => (
+                <tr
+                  key={member.id}
+                  className="transition hover:bg-slate-800/40"
+                >
+                  <td className="px-6 py-4">
+                    <Link
+                      href={`/staff/${member.id}`}
+                      className="text-sm font-medium text-slate-100 hover:text-emerald-300"
+                    >
+                      {member.displayName}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-slate-300">{member.email}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex flex-wrap gap-2">
+                      {member.roles.length ? (
+                        member.roles.map((role) => <RoleBadge key={role} role={role} />)
+                      ) : (
+                        <span className="text-xs text-slate-500">—</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4">
+                    <PasskeyPill enrolled={member.passkeyEnrolled} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-col gap-3 text-sm text-slate-400 lg:flex-row lg:items-center lg:justify-between">
+        <span>
+          {totalCount === 0
+            ? 'No staff found'
+            : `Showing ${from.toLocaleString()}-${to.toLocaleString()} of ${totalCount.toLocaleString()}`}
+        </span>
+        <div className="flex items-center gap-3">
+          <Link
+            href={buildPageHref(Math.max(1, page - 1), query)}
+            aria-disabled={page <= 1}
+            className={clsx(
+              'rounded-full border border-slate-700/70 px-4 py-1.5 text-sm font-medium text-slate-200 transition',
+              page > 1
+                ? 'hover:border-emerald-400/50 hover:text-emerald-200'
+                : 'cursor-not-allowed opacity-40'
+            )}
+            tabIndex={page > 1 ? undefined : -1}
+          >
+            Previous
+          </Link>
+          <span className="text-xs text-slate-500">
+            Page {Math.min(page, totalPages).toLocaleString()} of {totalPages.toLocaleString()}
+          </span>
+          <Link
+            href={buildPageHref(Math.min(totalPages, page + 1), query)}
+            aria-disabled={page >= totalPages}
+            className={clsx(
+              'rounded-full border border-slate-700/70 px-4 py-1.5 text-sm font-medium text-slate-200 transition',
+              page < totalPages
+                ? 'hover:border-emerald-400/50 hover:text-emerald-200'
+                : 'cursor-not-allowed opacity-40'
+            )}
+            tabIndex={page < totalPages ? undefined : -1}
+          >
+            Next
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/console/lib/data/staff.ts
+++ b/apps/console/lib/data/staff.ts
@@ -1,0 +1,158 @@
+import { createSupabaseServiceRoleClient } from '../supabase';
+
+export type StaffDirectoryEntry = {
+  id: string;
+  email: string;
+  displayName: string;
+  passkeyEnrolled: boolean;
+  roles: string[];
+};
+
+export type StaffDirectoryQueryOptions = {
+  q?: string;
+  limit?: number;
+  offset?: number;
+};
+
+function normaliseStaffRow(row: StaffUserRow, roleMap: Map<string, string[]>): StaffDirectoryEntry {
+  const roles = roleMap.get(row.user_id) ?? [];
+  return {
+    id: row.user_id,
+    email: row.email.toLowerCase(),
+    displayName: row.display_name ?? row.email,
+    passkeyEnrolled: Boolean(row.passkey_enrolled),
+    roles
+  };
+}
+
+type StaffUserRow = {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  passkey_enrolled: boolean | null;
+};
+
+type StaffRoleMembershipRow = {
+  user_id: string;
+  staff_roles: {
+    name: string;
+  } | null;
+};
+
+function escapeILike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+async function fetchRolesForUserIds(userIds: string[]): Promise<Map<string, string[]>> {
+  const roleMap = new Map<string, string[]>();
+
+  if (!userIds.length) {
+    return roleMap;
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  const { data, error } = await (supabase.from('staff_role_members') as any)
+    .select('user_id, staff_roles ( name )')
+    .in('user_id', userIds);
+
+  if (error) {
+    throw error;
+  }
+
+  const memberships = (data as StaffRoleMembershipRow[] | null) ?? [];
+
+  for (const membership of memberships) {
+    const roleName = membership.staff_roles?.name;
+    if (!roleName) {
+      continue;
+    }
+
+    if (!roleMap.has(membership.user_id)) {
+      roleMap.set(membership.user_id, []);
+    }
+
+    roleMap.get(membership.user_id)!.push(roleName);
+  }
+
+  return roleMap;
+}
+
+export async function getCurrentStaffWithRoles(email: string): Promise<StaffDirectoryEntry | null> {
+  const supabase = createSupabaseServiceRoleClient();
+
+  const { data, error } = await (supabase.from('staff_users') as any)
+    .select('user_id, email, display_name, passkey_enrolled')
+    .eq('email', email.toLowerCase())
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  const staffRow = (data as StaffUserRow | null) ?? null;
+
+  if (!staffRow) {
+    return null;
+  }
+
+  const roles = await fetchRolesForUserIds([staffRow.user_id]);
+
+  return normaliseStaffRow(staffRow, roles);
+}
+
+export async function getStaffByIdWithRoles(userId: string): Promise<StaffDirectoryEntry | null> {
+  const supabase = createSupabaseServiceRoleClient();
+
+  const { data, error } = await (supabase.from('staff_users') as any)
+    .select('user_id, email, display_name, passkey_enrolled')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  const staffRow = (data as StaffUserRow | null) ?? null;
+
+  if (!staffRow) {
+    return null;
+  }
+
+  const roles = await fetchRolesForUserIds([userId]);
+
+  return normaliseStaffRow(staffRow, roles);
+}
+
+export async function getAllStaffWithRoles({
+  q,
+  limit = 25,
+  offset = 0
+}: StaffDirectoryQueryOptions): Promise<{ staff: StaffDirectoryEntry[]; count: number }> {
+  const supabase = createSupabaseServiceRoleClient();
+
+  const query = (supabase.from('staff_users') as any)
+    .select('user_id, email, display_name, passkey_enrolled', { count: 'exact' })
+    .order('display_name', { ascending: true })
+    .range(offset, offset + limit - 1);
+
+  if (q && q.trim()) {
+    const searchTerm = escapeILike(q.trim());
+    query.or(`display_name.ilike.%${searchTerm}%,email.ilike.%${searchTerm}%`);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data as StaffUserRow[] | null) ?? [];
+  const userIds = rows.map((row) => row.user_id);
+  const roleMap = await fetchRolesForUserIds(userIds);
+
+  return {
+    staff: rows.map((row) => normaliseStaffRow(row, roleMap)),
+    count: count ?? rows.length
+  };
+}


### PR DESCRIPTION
## Summary
- add service-role data helpers and a server-rendered staff directory with search, pagination, and passkey status pills
- expose a Staff nav entry only for security_admin operators and surface Access Denied when RBAC checks fail
- scaffold the staff member detail view that links from each row and surfaces profile metadata

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68cfc63fc40c832db127c2c72ebfc471