### PR TITLE
feat(console): add audit log viewer

### DIFF
--- a/apps/console/app/audit/export/route.ts
+++ b/apps/console/app/audit/export/route.ts
@@ -1,0 +1,98 @@
+import { headers } from 'next/headers';
+import { requireStaff } from '../../../lib/auth';
+import { getAnalyticsClient } from '../../../lib/analytics';
+import { listAuditEvents } from '../../../lib/data/audit';
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+function buildFilename(now: Date): string {
+  return `audit-${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}.csv`;
+}
+
+function escapeCsv(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function normaliseTimestamp(timestamp: string | null): string {
+  if (!timestamp) {
+    return '';
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  return date.toISOString();
+}
+
+function serialiseMeta(meta: unknown): string {
+  if (meta === null || typeof meta === 'undefined') {
+    return '';
+  }
+
+  if (typeof meta === 'string') {
+    return meta;
+  }
+
+  try {
+    return JSON.stringify(meta);
+  } catch {
+    return String(meta);
+  }
+}
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const staffUser = await requireStaff();
+  const headerBag = headers();
+  const correlationId = headerBag.get('x-correlation-id') ?? crypto.randomUUID();
+  const events = await listAuditEvents();
+
+  if (events.length === 0) {
+    return new Response(null, { status: 204 });
+  }
+
+  const headerRow = 'id,ts,actor_email,action,target_type,target_id,ip,meta';
+  const dataRows = events.map((event) => {
+    const cells = [
+      event.id,
+      normaliseTimestamp(event.occurredAt),
+      event.actorEmail ?? '',
+      event.action ?? '',
+      event.targetType ?? '',
+      event.targetId ?? '',
+      event.ip ?? '',
+      serialiseMeta(event.meta)
+    ];
+
+    return cells.map((cell) => escapeCsv(cell)).join(',');
+  });
+
+  const csvContent = [headerRow, ...dataRows].join('\n');
+  const now = new Date();
+  const filename = buildFilename(now);
+
+  const analytics = getAnalyticsClient();
+  analytics.capture('audit_events_exported', {
+    user: staffUser.analyticsId,
+    count: events.length,
+    correlation_id: correlationId,
+    env: process.env.NODE_ENV ?? 'development'
+  });
+
+  return new Response(csvContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store'
+    }
+  });
+}

--- a/apps/console/app/audit/page.tsx
+++ b/apps/console/app/audit/page.tsx
@@ -1,0 +1,113 @@
+import { headers } from 'next/headers';
+import { requireStaff } from '../../lib/auth';
+import { getAnalyticsClient } from '../../lib/analytics';
+import { listAuditEvents } from '../../lib/data/audit';
+import { AuditMetaDetails } from '../../components/AuditMetaDetails';
+
+function formatUtc(timestamp: string | null): string {
+  if (!timestamp) {
+    return '—';
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} UTC`;
+}
+
+function formatTarget(targetType: string | null, targetId: string | null): string {
+  const trimmedType = targetType?.trim() ?? '';
+  const trimmedId = targetId?.trim() ?? '';
+
+  if (!trimmedType && !trimmedId) {
+    return '—';
+  }
+
+  if (trimmedType && trimmedId) {
+    return `${trimmedType} • ${trimmedId}`;
+  }
+
+  return trimmedType || trimmedId;
+}
+
+export const runtime = 'nodejs';
+
+export default async function AuditPage() {
+  const staffUser = await requireStaff();
+  const headerBag = headers();
+  const correlationId = headerBag.get('x-correlation-id') ?? crypto.randomUUID();
+  const events = await listAuditEvents();
+
+  const analytics = getAnalyticsClient();
+  analytics.capture('staff_console_viewed', {
+    path: '/audit',
+    correlation_id: correlationId,
+    env: process.env.NODE_ENV ?? 'development',
+    user: staffUser.analyticsId
+  });
+
+  const hasEvents = events.length > 0;
+
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="audit-heading">
+        <div className="panel__header">
+          <div>
+            <h1 id="audit-heading">Audit</h1>
+            <p className="muted">Latest security-relevant activity captured by the platform.</p>
+          </div>
+          <form action="/audit/export" method="get">
+            <button type="submit" className="button secondary small">
+              Export CSV
+            </button>
+          </form>
+        </div>
+
+        <div className="table-wrapper" role="region" aria-live="polite">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Time (UTC)</th>
+                <th scope="col">Actor</th>
+                <th scope="col">Action</th>
+                <th scope="col">Target</th>
+                <th scope="col">IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!hasEvents && (
+                <tr>
+                  <td colSpan={5} className="empty">
+                    <div className="muted">
+                      No audit events available yet.
+                      <br />
+                      Ensure a <code>public.console_audit_events</code> view or <code>public.audit_events</code> table exists and is populated
+                      by the backend.
+                    </div>
+                  </td>
+                </tr>
+              )}
+              {events.map((event) => (
+                <tr key={event.id}>
+                  <td>{formatUtc(event.occurredAt)}</td>
+                  <td>{event.actorEmail ?? '—'}</td>
+                  <td>
+                    <div className="audit-action">
+                      <span>{event.action ?? '—'}</span>
+                      {event.meta ? <AuditMetaDetails meta={event.meta} /> : null}
+                    </div>
+                  </td>
+                  <td>{formatTarget(event.targetType, event.targetId)}</td>
+                  <td>{event.ip ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/console/components/AuditMetaDetails.tsx
+++ b/apps/console/components/AuditMetaDetails.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useId, useMemo, useState } from 'react';
+
+type AuditMetaDetailsProps = {
+  meta: unknown;
+};
+
+function serialiseMeta(meta: unknown): string {
+  if (meta === null || typeof meta === 'undefined') {
+    return '';
+  }
+
+  if (typeof meta === 'string') {
+    try {
+      const parsed = JSON.parse(meta);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return meta;
+    }
+  }
+
+  try {
+    return JSON.stringify(meta, null, 2);
+  } catch {
+    return String(meta);
+  }
+}
+
+export function AuditMetaDetails({ meta }: AuditMetaDetailsProps) {
+  const [open, setOpen] = useState(false);
+  const detailsId = useId();
+  const pretty = useMemo(() => serialiseMeta(meta), [meta]);
+
+  if (meta === null || typeof meta === 'undefined') {
+    return null;
+  }
+
+  return (
+    <div className="audit-meta__container">
+      <button
+        type="button"
+        className="button ghost small"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        aria-controls={detailsId}
+      >
+        {open ? 'Hide JSON' : 'View JSON'}
+      </button>
+      <details id={detailsId} open={open} className="audit-meta__details">
+        <summary className="sr-only">Audit metadata</summary>
+        <pre className="metadata audit-meta__pre">{pretty}</pre>
+      </details>
+    </div>
+  );
+}

--- a/apps/console/lib/analytics.ts
+++ b/apps/console/lib/analytics.ts
@@ -17,8 +17,8 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/overview', label: 'Overview', permission: 'metrics.view' },
   { href: '/alerts', label: 'Alerts' },
   { href: '/investigations', label: 'Investigations' },
-  { href: '/audit-events', label: 'Audit Events', permission: 'audit.read' },
-  { href: '/releases', label: 'Releases', permission: 'releases.simulate' }
+  { href: '/releases', label: 'Releases', permission: 'releases.simulate' },
+  { href: '/audit', label: 'Audit' }
 ];
 
 class AnalyticsClient {

--- a/apps/console/lib/data/audit.ts
+++ b/apps/console/lib/data/audit.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import { createSupabaseServiceRoleClient } from '../supabase';
+
+const AUDIT_RELATIONS = ['console_audit_events', 'audit_events'] as const;
+
+const AuditRowSchema = z.object({
+  id: z.union([z.string(), z.number()]).optional().nullable(),
+  ts: z.union([z.string(), z.date()]).optional().nullable(),
+  actor_email: z.string().optional().nullable(),
+  action: z.string().optional().nullable(),
+  target_type: z.string().optional().nullable(),
+  target_id: z.string().optional().nullable(),
+  ip: z.string().optional().nullable(),
+  meta: z.unknown().optional().nullable()
+});
+
+type AuditRow = z.infer<typeof AuditRowSchema>;
+
+export type AuditEvent = {
+  id: string;
+  occurredAt: string | null;
+  actorEmail: string | null;
+  action: string | null;
+  targetType: string | null;
+  targetId: string | null;
+  ip: string | null;
+  meta: unknown | null;
+};
+
+function coerceLimit(limit: number | undefined, fallback: number): number {
+  if (!Number.isFinite(limit ?? NaN)) {
+    return fallback;
+  }
+
+  const value = Math.floor(limit ?? fallback);
+  if (value <= 0) {
+    return fallback;
+  }
+
+  return value;
+}
+
+function normaliseRow(row: AuditRow, index: number): AuditEvent {
+  const idValue = row.id;
+  const occurredAtValue = row.ts;
+
+  return {
+    id: typeof idValue === 'number' ? String(idValue) : idValue ?? `row-${index}`,
+    occurredAt:
+      occurredAtValue instanceof Date
+        ? occurredAtValue.toISOString()
+        : typeof occurredAtValue === 'string'
+        ? occurredAtValue
+        : null,
+    actorEmail: row.actor_email ?? null,
+    action: row.action ?? null,
+    targetType: row.target_type ?? null,
+    targetId: row.target_id ?? null,
+    ip: row.ip ?? null,
+    meta: row.meta ?? null
+  };
+}
+
+export async function listAuditEvents(limit = 200): Promise<AuditEvent[]> {
+  const supabase = createSupabaseServiceRoleClient();
+  const finalLimit = coerceLimit(limit, 200);
+
+  for (const relation of AUDIT_RELATIONS) {
+    try {
+      const { data, error } = await (supabase
+        .from(relation) as any)
+        .select('id, ts, actor_email, action, target_type, target_id, ip, meta')
+        .order('ts', { ascending: false, nullsFirst: false })
+        .limit(finalLimit);
+
+      if (error) {
+        if (error.code === '42P01') {
+          console.warn(`[audit] relation "${relation}" missing, checking fallback`);
+          continue;
+        }
+
+        console.error(`[audit] failed to list events from ${relation}`, error);
+        return [];
+      }
+
+      const rows = Array.isArray(data) ? data : [];
+      const parsed: AuditEvent[] = [];
+
+      rows.forEach((row, index) => {
+        const result = AuditRowSchema.safeParse(row);
+        if (!result.success) {
+          console.warn('[audit] skipping row due to validation error', result.error.flatten());
+          return;
+        }
+
+        parsed.push(normaliseRow(result.data, index));
+      });
+
+      return parsed;
+    } catch (error: any) {
+      if (error?.code === '42P01') {
+        console.warn(`[audit] relation "${relation}" missing (caught)`, error?.message ?? error);
+        continue;
+      }
+
+      console.error('[audit] unexpected error loading events', error);
+      return [];
+    }
+  }
+
+  return [];
+}

--- a/apps/console/styles/globals.css
+++ b/apps/console/styles/globals.css
@@ -18,6 +18,18 @@ body {
   width: 100%;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -281,6 +293,37 @@ ol {
   white-space: pre-wrap;
 }
 
+.audit-action {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.audit-meta__container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.audit-meta__details {
+  width: 100%;
+}
+
+.audit-meta__details:not([open]) {
+  display: none;
+}
+
+.audit-meta__pre {
+  max-height: 240px;
+  overflow: auto;
+  margin: 0;
+  background: rgba(14, 165, 233, 0.04);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  border: 1px solid var(--color-border);
+}
+
 .table-footer {
   display: flex;
   justify-content: space-between;
@@ -294,7 +337,7 @@ ol {
   gap: 12px;
 }
 
-.button {
+.button { 
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -306,6 +349,11 @@ ol {
   font-weight: 500;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.small {
+  padding: 6px 12px;
+  font-size: 0.8rem;
 }
 
 .button:hover {
@@ -337,7 +385,7 @@ ol {
   transform: none;
 }
 
-.filters {
+.filters { 
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 16px;


### PR DESCRIPTION
## Summary
- add an audit console page gated to staff that renders events or a setup note
- expose a Supabase-backed listAuditEvents helper with zod parsing and CSV export route
- enhance shared styles and navigation to surface the audit view with expandable metadata

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68cfcc4c121c832d8c13de1ea4b10375