### PR TITLE
feat(console): add admin people view

### DIFF
--- a/apps/console/app/admin/people/page.tsx
+++ b/apps/console/app/admin/people/page.tsx
@@ -1,0 +1,85 @@
+import { cookies, headers } from 'next/headers';
+import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { PeopleTable, type AdminPersonRecord } from '../../../components/admin/PeopleTable';
+import { getStaffUser } from '../../../lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+async function fetchPeople(baseUrl: string, emailHeader: string | null) {
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const headersMap = new Headers();
+  if (cookieHeader) {
+    headersMap.set('cookie', cookieHeader);
+  }
+  if (emailHeader) {
+    headersMap.set('cf-access-authenticated-user-email', emailHeader);
+  }
+
+  const response = await fetch(`${baseUrl}/api/admin/people`, {
+    cache: 'no-store',
+    headers: headersMap
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    return { status: response.status as const, people: null };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load staff directory (${response.status})`);
+  }
+
+  const people = (await response.json()) as AdminPersonRecord[];
+  return { status: 200 as const, people };
+}
+
+export default async function AdminPeoplePage() {
+  const staffUser = await getStaffUser();
+
+  if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
+    return <AccessDeniedNotice />;
+  }
+
+  const headerBag = headers();
+  const host = headerBag.get('x-forwarded-host') ?? headerBag.get('host');
+  const protoHeader = headerBag.get('x-forwarded-proto');
+
+  let baseUrl: string;
+  if (host) {
+    const normalisedHost = host.toLowerCase();
+    const defaultProto = normalisedHost.includes('localhost') || normalisedHost.includes('127.0.0.1') ? 'http' : 'https';
+    const protocol = protoHeader ?? defaultProto;
+    baseUrl = `${protocol}://${host}`;
+  } else {
+    baseUrl = process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
+  }
+
+  const headerEmail =
+    headerBag.get('cf-access-authenticated-user-email')
+    ?? headerBag.get('Cf-Access-Authenticated-User-Email')
+    ?? staffUser.email;
+
+  const { status, people } = await fetchPeople(baseUrl, headerEmail);
+
+  if (status === 401 || status === 403) {
+    return <AccessDeniedNotice />;
+  }
+
+  if (!people) {
+    throw new Error('People payload missing');
+  }
+
+  return (
+    <div className="page">
+      <PeopleTable people={people} />
+    </div>
+  );
+}

--- a/apps/console/app/api/admin/people/route.ts
+++ b/apps/console/app/api/admin/people/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { getRequesterEmail, getUserRolesByEmail } from '../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let roles: string[];
+  try {
+    roles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  const hasSecurityAdmin = roles.some((role) => role.toLowerCase() === 'security_admin');
+  if (!hasSecurityAdmin) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  type StaffRow = {
+    user_id: string;
+    email: string;
+    display_name: string | null;
+    passkey_enrolled: boolean | null;
+    staff_role_members?: Array<{
+      staff_roles?: {
+        name: string | null;
+      } | null;
+    }> | null;
+  };
+
+  const { data, error } = await (supabase.from('staff_users') as any)
+    .select(
+      `user_id, email, display_name, passkey_enrolled,
+        staff_role_members:staff_role_members (
+          staff_roles:staff_roles ( name )
+        )`
+    )
+    .order('email', { ascending: true });
+
+  if (error) {
+    return new Response('failed to load staff', { status: 500 });
+  }
+
+  const rows = (data as StaffRow[] | null) ?? [];
+
+  const staff = rows.map((row) => {
+    const roleNames = (row.staff_role_members ?? [])
+      .map((membership) => membership?.staff_roles?.name?.trim() ?? null)
+      .filter((role): role is string => Boolean(role));
+
+    roleNames.sort((a, b) => a.localeCompare(b));
+
+    return {
+      user_id: row.user_id,
+      email: row.email.toLowerCase(),
+      display_name: row.display_name,
+      passkey_enrolled: Boolean(row.passkey_enrolled),
+      roles: Array.from(new Set(roleNames))
+    };
+  });
+
+  return NextResponse.json(staff);
+}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -64,7 +64,10 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
 
   const navItems = [...buildNavItems(staffUser.permissions)];
 
-  if (staffUser.roles.includes('security_admin')) {
+  const hasSecurityAdminRole = staffUser.roles.some((role) => role.toLowerCase() === 'security_admin');
+
+  if (hasSecurityAdminRole) {
+    navItems.push({ href: '/admin/people', label: 'Admin' });
     navItems.push({ href: '/staff', label: 'Staff' });
   }
 

--- a/apps/console/app/overview/page.tsx
+++ b/apps/console/app/overview/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { headers } from 'next/headers';
 import clsx from 'clsx';
 import { requireStaff } from '../../lib/auth';
@@ -105,6 +106,8 @@ export default async function OverviewPage() {
     openInvestigations
   };
 
+  const isSecurityAdmin = staffUser.roles.some((role) => role.toLowerCase() === 'security_admin');
+
   const analytics = getAnalyticsClient();
   analytics.capture('staff_console_viewed', {
     path: '/overview',
@@ -143,6 +146,20 @@ export default async function OverviewPage() {
           </header>
           <p className="muted">UTC timestamp, pulled from audit trail for evidence parity.</p>
         </article>
+        {isSecurityAdmin && (
+          <article className="card">
+            <header>
+              <h2>Admin</h2>
+            </header>
+            <p className="muted">Manage people &amp; roles.</p>
+            <Link
+              href="/admin/people"
+              className="mt-4 inline-flex items-center text-sm font-medium text-emerald-300 transition hover:text-emerald-200"
+            >
+              Open admin tools →
+            </Link>
+          </article>
+        )}
       </div>
 
       <div className="grid-two">

--- a/apps/console/components/admin/PeopleTable.tsx
+++ b/apps/console/components/admin/PeopleTable.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { RoleBadge } from '../RoleBadge';
+
+export type AdminPersonRecord = {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  passkey_enrolled: boolean;
+  roles: string[];
+};
+
+export type PeopleTableProps = {
+  people: AdminPersonRecord[];
+};
+
+function PasskeyBadge({ enrolled }: { enrolled: boolean }) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        enrolled
+          ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200'
+          : 'border-slate-700/70 bg-slate-800/80 text-slate-400'
+      )}
+    >
+      {enrolled ? 'Yes' : 'No'}
+    </span>
+  );
+}
+
+function filterPeople(people: AdminPersonRecord[], query: string) {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return people;
+  }
+
+  return people.filter((person) => {
+    const displayName = person.display_name ?? '';
+    return (
+      person.email.toLowerCase().includes(trimmed)
+      || displayName.toLowerCase().includes(trimmed)
+    );
+  });
+}
+
+export function PeopleTable({ people }: PeopleTableProps) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => filterPeople(people, query), [people, query]);
+
+  return (
+    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Admin directory</h1>
+          <p className="text-sm text-slate-400">
+            Staff enrolled in Torvus Console and their assigned roles.
+          </p>
+        </div>
+        <label
+          className={clsx(
+            'flex w-full items-center gap-2 rounded-full border border-slate-700 bg-slate-950/60 px-4 py-2 text-sm text-slate-200 focus-within:border-slate-500',
+            'lg:w-auto'
+          )}
+        >
+          <span className="sr-only">Filter staff</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter staff"
+            className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+          />
+        </label>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-800/60">
+        <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm text-slate-200">
+          <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th scope="col" className="px-6 py-3">
+                Email
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Display name
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Roles
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Passkey
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-12 text-center text-sm text-slate-400">
+                  No staff members match your filter.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((person) => (
+                <tr key={person.user_id} className="transition hover:bg-slate-800/40">
+                  <td className="px-6 py-4 text-sm font-medium text-slate-100">{person.email}</td>
+                  <td className="px-6 py-4 text-sm text-slate-300">{person.display_name ?? '—'}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex flex-wrap gap-2">
+                      {person.roles.length ? (
+                        person.roles.map((role) => <RoleBadge key={`${person.user_id}-${role}`} role={role} />)
+                      ) : (
+                        <span className="text-xs text-slate-500">—</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4">
+                    <PasskeyBadge enrolled={person.passkey_enrolled} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/console/tests/lib/auth.test.ts
+++ b/apps/console/tests/lib/auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRequesterEmail, getUserRolesByEmail } from '../../lib/auth';
+
+describe('getRequesterEmail', () => {
+  it('resolves email from Cloudflare header and normalises casing', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'Cf-Access-Authenticated-User-Email': ' Admin@Example.com '
+      }
+    });
+
+    expect(getRequesterEmail(request)).toBe('admin@example.com');
+  });
+
+  it('falls back to x-user-email header', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'x-user-email': 'user@example.com'
+      }
+    });
+
+    expect(getRequesterEmail(request)).toBe('user@example.com');
+  });
+
+  it('returns null when no header present', () => {
+    const request = new Request('https://example.com');
+
+    expect(getRequesterEmail(request)).toBeNull();
+  });
+});
+
+describe('getUserRolesByEmail', () => {
+  it('returns sorted unique role names', async () => {
+    const maybeSingle = vi.fn(async () => ({
+      data: {
+        staff_role_members: [
+          { staff_roles: { name: 'security_admin' } },
+          { staff_roles: { name: 'investigator' } },
+          { staff_roles: { name: 'security_admin' } }
+        ]
+      },
+      error: null
+    }));
+
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ select }));
+
+    const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];
+
+    const roles = await getUserRolesByEmail('Admin@Example.com', client);
+
+    expect(from).toHaveBeenCalledWith('staff_users');
+    expect(eq).toHaveBeenCalledWith('email', 'admin@example.com');
+    expect(roles).toEqual(['investigator', 'security_admin']);
+  });
+
+  it('returns empty array when email missing', async () => {
+    const from = vi.fn();
+    const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];
+
+    const roles = await getUserRolesByEmail('   ', client);
+
+    expect(roles).toEqual([]);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when record not found', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: { code: 'PGRST116' } }));
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ select }));
+
+    const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];
+
+    const roles = await getUserRolesByEmail('unknown@example.com', client);
+
+    expect(roles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add server auth helpers to resolve requester email and staff roles
- expose /admin/people API and UI guarded to security_admin role
- surface Admin navigation and overview tile for authorised staff

## Testing
- pnpm --filter @torvus/console test

------
https://chatgpt.com/codex/tasks/task_b_68cfcff1e1d4832d8e61372f8a7fe2b8