### PR TITLE
feat: add investigations case management module

### DIFF
--- a/apps/console/app/api/investigations/[id]/events/route.ts
+++ b/apps/console/app/api/investigations/[id]/events/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logAudit } from '../../../../../server/audit';
+import { getInvestigationById, type InvestigationEvent } from '../../../../../lib/data/investigations';
+import { resolveViewer, canManageInvestigations, canViewInvestigations } from '../../utils';
+
+const noteSchema = z.object({
+  message: z.string().min(1).max(2000)
+});
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const viewer = await resolveViewer(request);
+  if (viewer.type === 'error') {
+    return viewer.response;
+  }
+
+  const { supabase, staff, roles } = viewer;
+
+  if (!canViewInvestigations(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  if (!canManageInvestigations(roles) || !staff) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  const investigation = await getInvestigationById(params.id);
+  if (!investigation) {
+    return new Response('not found', { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const parsed = noteSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(parsed.error.errors[0]?.message ?? 'invalid payload', { status: 400 });
+  }
+
+  const message = parsed.data.message.trim();
+
+  const { data: insertedRows, error: insertError } = await (supabase.from('investigation_events') as any)
+    .insert({
+      investigation_id: params.id,
+      actor_user_id: staff.user_id,
+      kind: 'note',
+      message,
+      meta: {}
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    console.error('Failed to insert investigation note', insertError);
+    return new Response('failed to add note', { status: 500 });
+  }
+
+  const eventId = (insertedRows as { id: string }).id;
+
+  const { data: eventRows, error: selectError } = await (supabase.from('investigation_events_with_actor') as any)
+    .select('id, investigation_id, created_at, actor_user_id, kind, message, meta, actor_email, actor_display_name')
+    .eq('id', eventId)
+    .maybeSingle();
+
+  if (selectError) {
+    console.error('Failed to load inserted note', selectError);
+    return new Response('failed to load note', { status: 500 });
+  }
+
+  const row = eventRows as any;
+  const event: InvestigationEvent = {
+    id: row.id,
+    investigationId: row.investigation_id,
+    createdAt: row.created_at,
+    actor: {
+      id: row.actor_user_id ?? null,
+      email: row.actor_email ?? null,
+      displayName: row.actor_display_name ?? null
+    },
+    kind: row.kind,
+    message: row.message ?? null,
+    meta: row.meta ?? {}
+  };
+
+  await logAudit(
+    {
+      action: 'investigation_note_added',
+      targetType: 'investigation',
+      targetId: params.id,
+      resource: 'console.investigations',
+      meta: {
+        message_length: message.length
+      }
+    },
+    request
+  );
+
+  return NextResponse.json({ event }, { status: 201 });
+}

--- a/apps/console/app/api/investigations/[id]/route.ts
+++ b/apps/console/app/api/investigations/[id]/route.ts
@@ -2,11 +2,10 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logAudit, type AuditLogInput } from '../../../../server/audit';
 import {
-  getInvestigationById,
   INVESTIGATION_SEVERITIES,
-  INVESTIGATION_STATUSES,
-  type InvestigationEvent
-} from '../../../../lib/data/investigations';
+  INVESTIGATION_STATUSES
+} from '../../../../lib/investigations/constants';
+import { getInvestigationById, type InvestigationEvent } from '../../../../lib/data/investigations';
 import {
   resolveViewer,
   canManageInvestigations,

--- a/apps/console/app/api/investigations/[id]/route.ts
+++ b/apps/console/app/api/investigations/[id]/route.ts
@@ -1,0 +1,361 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logAudit, type AuditLogInput } from '../../../../server/audit';
+import {
+  getInvestigationById,
+  INVESTIGATION_SEVERITIES,
+  INVESTIGATION_STATUSES,
+  type InvestigationEvent
+} from '../../../../lib/data/investigations';
+import {
+  resolveViewer,
+  canManageInvestigations,
+  canViewInvestigations,
+  loadStaffSummaries
+} from '../utils';
+
+const updateSchema = z
+  .object({
+    title: z.string().optional(),
+    status: z.enum(INVESTIGATION_STATUSES).optional(),
+    severity: z.enum(INVESTIGATION_SEVERITIES).optional(),
+    assignedTo: z.union([z.string(), z.null()]).optional(),
+    summary: z.string().optional(),
+    tags: z.array(z.string()).optional()
+  })
+  .refine((value) => Object.keys(value).length > 0, { message: 'no fields provided' });
+
+const uuidSchema = z.string().uuid();
+
+type InvestigationRow = {
+  id: string;
+  title: string;
+  status: string;
+  severity: string;
+  assigned_to: string | null;
+  summary: string | null;
+  tags: string[] | null;
+};
+
+function normaliseTags(input: string[] | undefined): string[] {
+  if (!input) {
+    return [];
+  }
+  const unique = new Set<string>();
+  for (const tag of input) {
+    const trimmed = tag.trim();
+    if (trimmed) {
+      unique.add(trimmed);
+    }
+  }
+  return Array.from(unique);
+}
+
+function safeJsonEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const viewer = await resolveViewer(request);
+  if (viewer.type === 'error') {
+    return viewer.response;
+  }
+
+  const { supabase, staff, roles } = viewer;
+
+  if (!canViewInvestigations(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  if (!canManageInvestigations(roles) || !staff) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(parsed.error.errors[0]?.message ?? 'invalid payload', { status: 400 });
+  }
+
+  const payload = parsed.data;
+
+  const { data: currentRow, error: fetchError } = await (supabase.from('investigations') as any)
+    .select('id, title, status, severity, assigned_to, summary, tags')
+    .eq('id', params.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error('Failed to load investigation for update', fetchError);
+    return new Response('failed to load investigation', { status: 500 });
+  }
+
+  if (!currentRow) {
+    return new Response('not found', { status: 404 });
+  }
+
+  const current = currentRow as InvestigationRow;
+
+  const updates: Record<string, unknown> = {};
+  const eventsToInsert: Array<{
+    kind: 'note' | 'status_change' | 'assignment_change' | 'attachment';
+    message: string | null;
+    meta: Record<string, unknown>;
+  }> = [];
+  const auditEntries: AuditLogInput[] = [];
+
+  if (payload.title !== undefined) {
+    const trimmed = payload.title.trim();
+    if (!trimmed) {
+      return new Response('title cannot be empty', { status: 400 });
+    }
+    if (trimmed !== current.title) {
+      updates.title = trimmed;
+      eventsToInsert.push({
+        kind: 'note',
+        message: 'Title updated',
+        meta: {
+          from: current.title,
+          to: trimmed
+        }
+      });
+      auditEntries.push({
+        action: 'investigation_title_update',
+        targetType: 'investigation',
+        targetId: params.id,
+        resource: 'console.investigations',
+        meta: { from: current.title, to: trimmed }
+      });
+    }
+  }
+
+  if (payload.status && payload.status !== current.status) {
+    updates.status = payload.status;
+    eventsToInsert.push({
+      kind: 'status_change',
+      message: `Status changed to ${payload.status.replace('_', ' ')}`,
+      meta: {
+        from: current.status,
+        to: payload.status
+      }
+    });
+    auditEntries.push({
+      action: 'investigation_status_change',
+      targetType: 'investigation',
+      targetId: params.id,
+      resource: 'console.investigations',
+      meta: { from: current.status, to: payload.status }
+    });
+  }
+
+  if (payload.severity && payload.severity !== current.severity) {
+    updates.severity = payload.severity;
+    eventsToInsert.push({
+      kind: 'note',
+      message: `Severity changed to ${payload.severity}`,
+      meta: {
+        from: current.severity,
+        to: payload.severity
+      }
+    });
+    auditEntries.push({
+      action: 'investigation_severity_change',
+      targetType: 'investigation',
+      targetId: params.id,
+      resource: 'console.investigations',
+      meta: { from: current.severity, to: payload.severity }
+    });
+  }
+
+  if (payload.assignedTo !== undefined) {
+    let nextAssignee: string | null;
+    if (payload.assignedTo === null || payload.assignedTo === '') {
+      nextAssignee = null;
+    } else {
+      const trimmed = payload.assignedTo.trim();
+      const parsedAssignee = uuidSchema.safeParse(trimmed);
+      if (!parsedAssignee.success) {
+        return new Response('invalid assignee id', { status: 400 });
+      }
+      nextAssignee = parsedAssignee.data;
+    }
+
+    if (nextAssignee !== (current.assigned_to ?? null)) {
+      updates.assigned_to = nextAssignee;
+
+      let message = 'Assignment updated';
+      try {
+        const summaries = await loadStaffSummaries(supabase, [current.assigned_to, nextAssignee]);
+        const nextSummary = nextAssignee ? summaries.get(nextAssignee) : null;
+        const fromSummary = current.assigned_to ? summaries.get(current.assigned_to) : null;
+        const fromLabel = fromSummary?.display_name ?? fromSummary?.email ?? current.assigned_to ?? 'Unassigned';
+        const toLabel = nextSummary?.display_name ?? nextSummary?.email ?? (nextAssignee ?? 'Unassigned');
+        message = nextAssignee ? `Assigned to ${toLabel}` : 'Unassigned';
+        eventsToInsert.push({
+          kind: 'assignment_change',
+          message,
+          meta: {
+            from_user_id: current.assigned_to,
+            from_label: fromLabel,
+            to_user_id: nextAssignee,
+            to_label: toLabel
+          }
+        });
+      } catch (summaryError) {
+        console.warn('Failed to resolve staff summary for assignment change', summaryError);
+        eventsToInsert.push({
+          kind: 'assignment_change',
+          message: nextAssignee ? 'Assignment updated' : 'Unassigned',
+          meta: {
+            from_user_id: current.assigned_to,
+            to_user_id: nextAssignee
+          }
+        });
+      }
+
+      auditEntries.push({
+        action: 'investigation_assignment_change',
+        targetType: 'investigation',
+        targetId: params.id,
+        resource: 'console.investigations',
+        meta: {
+          from: current.assigned_to,
+          to: nextAssignee
+        }
+      });
+    }
+  }
+
+  if (payload.summary !== undefined) {
+    const trimmed = payload.summary.trim();
+    const canonical = current.summary ?? '';
+    if (trimmed !== canonical) {
+      updates.summary = trimmed ? trimmed : null;
+      eventsToInsert.push({
+        kind: 'note',
+        message: 'Summary updated',
+        meta: {
+          previous: canonical,
+          next: trimmed
+        }
+      });
+      auditEntries.push({
+        action: 'investigation_summary_update',
+        targetType: 'investigation',
+        targetId: params.id,
+        resource: 'console.investigations',
+        meta: {
+          previous: canonical,
+          next: trimmed
+        }
+      });
+    }
+  }
+
+  if (payload.tags !== undefined) {
+    const nextTags = normaliseTags(payload.tags);
+    const currentTags = Array.isArray(current.tags) ? current.tags : [];
+    if (!safeJsonEqual(nextTags, currentTags)) {
+      updates.tags = nextTags;
+      eventsToInsert.push({
+        kind: 'note',
+        message: 'Tags updated',
+        meta: {
+          previous: currentTags,
+          next: nextTags
+        }
+      });
+      auditEntries.push({
+        action: 'investigation_tags_update',
+        targetType: 'investigation',
+        targetId: params.id,
+        resource: 'console.investigations',
+        meta: {
+          previous: currentTags,
+          next: nextTags
+        }
+      });
+    }
+  }
+
+  if (Object.keys(updates).length === 0 && eventsToInsert.length === 0) {
+    const investigation = await getInvestigationById(params.id);
+    return NextResponse.json({ investigation });
+  }
+
+  const { error: updateError } = await (supabase.from('investigations') as any)
+    .update(updates)
+    .eq('id', params.id);
+
+  if (updateError) {
+    console.error('Failed to update investigation', updateError);
+    return new Response('failed to update investigation', { status: 500 });
+  }
+
+  let newEvents: InvestigationEvent[] = [];
+
+  if (eventsToInsert.length > 0) {
+    const payloadToInsert = eventsToInsert.map((event) => ({
+      investigation_id: params.id,
+      actor_user_id: staff.user_id,
+      kind: event.kind,
+      message: event.message,
+      meta: event.meta
+    }));
+
+    const { data: insertedRows, error: insertError } = await (supabase.from('investigation_events') as any)
+      .insert(payloadToInsert)
+      .select('id');
+
+    if (insertError) {
+      console.error('Failed to record investigation events', insertError);
+    } else {
+      const ids = ((insertedRows as Array<{ id: string }> | null) ?? []).map((row) => row.id);
+      if (ids.length) {
+        const { data: eventRows, error: selectError } = await (supabase.from('investigation_events_with_actor') as any)
+          .select('id, investigation_id, created_at, actor_user_id, kind, message, meta, actor_email, actor_display_name')
+          .in('id', ids)
+          .order('created_at', { ascending: false });
+
+        if (selectError) {
+          console.error('Failed to load inserted events', selectError);
+        } else {
+          newEvents = ((eventRows as any[]) ?? []).map((row) => ({
+            id: row.id,
+            investigationId: row.investigation_id,
+            createdAt: row.created_at,
+            actor: {
+              id: row.actor_user_id ?? null,
+              email: row.actor_email ?? null,
+              displayName: row.actor_display_name ?? null
+            },
+            kind: row.kind,
+            message: row.message ?? null,
+            meta: row.meta ?? {}
+          }));
+        }
+      }
+    }
+  }
+
+  const investigation = await getInvestigationById(params.id);
+
+  if (!investigation) {
+    return new Response('failed to load updated investigation', { status: 500 });
+  }
+
+  for (const entry of auditEntries) {
+    try {
+      await logAudit(entry, request);
+    } catch (auditError) {
+      console.error('Failed to write audit log', auditError);
+    }
+  }
+
+  return NextResponse.json({ investigation, events: newEvents });
+}

--- a/apps/console/app/api/investigations/route.ts
+++ b/apps/console/app/api/investigations/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logAudit } from '../../../server/audit';
+import {
+  getInvestigationById,
+  INVESTIGATION_SEVERITIES,
+  type InvestigationDetail
+} from '../../../lib/data/investigations';
+import {
+  resolveViewer,
+  canManageInvestigations,
+  canViewInvestigations
+} from './utils';
+
+const createSchema = z.object({
+  title: z.string().min(1).max(256),
+  severity: z.enum(INVESTIGATION_SEVERITIES).default('medium'),
+  summary: z.string().optional(),
+  tags: z.array(z.string()).optional()
+});
+
+function normaliseTags(input: string[] | undefined): string[] {
+  if (!input) {
+    return [];
+  }
+  const unique = new Set<string>();
+  for (const tag of input) {
+    const trimmed = tag.trim();
+    if (trimmed) {
+      unique.add(trimmed);
+    }
+  }
+  return Array.from(unique);
+}
+
+export async function POST(request: Request) {
+  const viewer = await resolveViewer(request);
+  if (viewer.type === 'error') {
+    return viewer.response;
+  }
+
+  const { supabase, staff, roles } = viewer;
+
+  if (!canViewInvestigations(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  if (!canManageInvestigations(roles) || !staff) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(parsed.error.errors[0]?.message ?? 'invalid payload', { status: 400 });
+  }
+
+  const data = parsed.data;
+  const title = data.title.trim();
+  const severity = data.severity;
+  const summary = data.summary?.trim() ?? '';
+  const tags = normaliseTags(data.tags);
+
+  const { data: inserted, error: insertError } = await (supabase.from('investigations') as any)
+    .insert({
+      title,
+      severity,
+      summary: summary || null,
+      tags,
+      opened_by: staff.user_id
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    console.error('Failed to create investigation', insertError);
+    return new Response('failed to create investigation', { status: 500 });
+  }
+
+  const investigationId = (inserted as { id: string }).id;
+  let investigation: InvestigationDetail | null = null;
+
+  try {
+    investigation = await getInvestigationById(investigationId);
+  } catch (lookupError) {
+    console.error('Failed to load created investigation', lookupError);
+  }
+
+  if (!investigation) {
+    return new Response('failed to load created investigation', { status: 500 });
+  }
+
+  await logAudit(
+    {
+      action: 'investigation_create',
+      targetType: 'investigation',
+      targetId: investigationId,
+      resource: 'console.investigations',
+      meta: {
+        severity,
+        tags,
+        opened_by: staff.user_id
+      }
+    },
+    request
+  );
+
+  return NextResponse.json({ investigation }, { status: 201 });
+}

--- a/apps/console/app/api/investigations/route.ts
+++ b/apps/console/app/api/investigations/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logAudit } from '../../../server/audit';
-import {
-  getInvestigationById,
-  INVESTIGATION_SEVERITIES,
-  type InvestigationDetail
-} from '../../../lib/data/investigations';
+import { INVESTIGATION_SEVERITIES } from '../../../lib/investigations/constants';
+import { getInvestigationById, type InvestigationDetail } from '../../../lib/data/investigations';
 import {
   resolveViewer,
   canManageInvestigations,

--- a/apps/console/app/api/investigations/utils.ts
+++ b/apps/console/app/api/investigations/utils.ts
@@ -1,0 +1,88 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import {
+  getRequesterEmail,
+  getStaffUserByEmail,
+  getUserRolesByEmail,
+  type StaffUserRecord
+} from '../../../lib/auth';
+
+export type ViewerOk = {
+  type: 'ok';
+  supabase: SupabaseClient<any>;
+  email: string;
+  roles: string[];
+  staff: StaffUserRecord | null;
+};
+
+export type ViewerError = {
+  type: 'error';
+  response: Response;
+};
+
+export type ViewerResolution = ViewerOk | ViewerError;
+
+const VIEW_ROLES = new Set(['security_admin', 'investigator', 'auditor']);
+const MANAGE_ROLES = new Set(['security_admin', 'investigator']);
+
+export async function resolveViewer(request: Request): Promise<ViewerResolution> {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return { type: 'error', response: new Response('unauthorized', { status: 401 }) };
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  try {
+    const [roles, staff] = await Promise.all([
+      getUserRolesByEmail(email, supabase),
+      getStaffUserByEmail(email, supabase)
+    ]);
+
+    return { type: 'ok', supabase, email, roles, staff } satisfies ViewerOk;
+  } catch (error) {
+    console.error('Failed to resolve viewer context', error);
+    return { type: 'error', response: new Response('failed to resolve viewer', { status: 500 }) };
+  }
+}
+
+export function canViewInvestigations(roles: string[]): boolean {
+  return roles.some((role) => VIEW_ROLES.has(role.toLowerCase()));
+}
+
+export function canManageInvestigations(roles: string[]): boolean {
+  return roles.some((role) => MANAGE_ROLES.has(role.toLowerCase()));
+}
+
+export async function loadStaffSummaries(
+  supabase: SupabaseClient<any>,
+  userIds: Array<string | null | undefined>
+): Promise<Map<string, { display_name: string | null; email: string | null }>> {
+  const filtered = Array.from(
+    new Set(
+      userIds
+        .map((id) => id?.trim())
+        .filter((value): value is string => Boolean(value))
+    )
+  );
+
+  const summary = new Map<string, { display_name: string | null; email: string | null }>();
+
+  if (!filtered.length) {
+    return summary;
+  }
+
+  const { data, error } = await (supabase.from('staff_users') as any)
+    .select('user_id, display_name, email')
+    .in('user_id', filtered);
+
+  if (error) {
+    throw error;
+  }
+
+  for (const row of (data as Array<{ user_id: string; display_name: string | null; email: string | null }> | null) ?? []) {
+    summary.set(row.user_id, { display_name: row.display_name, email: row.email });
+  }
+
+  return summary;
+}

--- a/apps/console/app/investigations/[id]/page.tsx
+++ b/apps/console/app/investigations/[id]/page.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { getStaffUser } from '../../../lib/auth';
+import {
+  getInvestigationById,
+  listInvestigationEvents,
+  type InvestigationDetail
+} from '../../../lib/data/investigations';
+import { getAllStaffWithRoles } from '../../../lib/data/staff';
+import InvestigationDetailClient from '../components/InvestigationDetailClient';
+
+export const metadata = {
+  title: 'Investigation detail | Torvus Console'
+};
+
+type PageParams = {
+  params: { id: string };
+};
+
+type StaffOption = {
+  id: string;
+  label: string;
+  email: string;
+};
+
+async function loadStaffOptions(): Promise<StaffOption[]> {
+  try {
+    const { staff } = await getAllStaffWithRoles({ limit: 200 });
+    return staff.map((entry) => ({
+      id: entry.id,
+      label: entry.displayName,
+      email: entry.email
+    }));
+  } catch (error) {
+    console.warn('Failed to load staff directory for assignments', error);
+    return [];
+  }
+}
+
+async function InvestigationDetailLoader({
+  investigation,
+  canManage
+}: {
+  investigation: InvestigationDetail;
+  canManage: boolean;
+}) {
+  const [events, staffOptions] = await Promise.all([
+    listInvestigationEvents(investigation.id),
+    loadStaffOptions()
+  ]);
+
+  return (
+    <InvestigationDetailClient
+      investigation={investigation}
+      events={events}
+      staffOptions={staffOptions}
+      canManage={canManage}
+    />
+  );
+}
+
+export default async function InvestigationDetailPage({ params }: PageParams) {
+  const staffUser = await getStaffUser();
+
+  if (!staffUser) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+      </div>
+    );
+  }
+
+  const hasViewPermission = staffUser.permissions.includes('investigations.view');
+
+  if (!hasViewPermission) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+        <p className="mt-4 max-w-md text-center text-sm text-slate-400">
+          Investigations require investigator, security administrator, or auditor privileges.
+        </p>
+      </div>
+    );
+  }
+
+  const investigation = await getInvestigationById(params.id);
+
+  if (!investigation) {
+    notFound();
+  }
+
+  const canManage = staffUser.permissions.includes('investigations.manage');
+
+  return (
+    <div className="flex flex-col gap-6 py-6">
+      <Link
+        href="/investigations"
+        className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-300 transition hover:text-emerald-200"
+      >
+        ← Back to investigations
+      </Link>
+
+      <Suspense fallback={<div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 text-slate-200">Loading…</div>}>
+        <InvestigationDetailLoader investigation={investigation} canManage={canManage} />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/console/app/investigations/components/InvestigationDetailClient.tsx
+++ b/apps/console/app/investigations/components/InvestigationDetailClient.tsx
@@ -1,0 +1,462 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import clsx from 'clsx';
+import {
+  INVESTIGATION_SEVERITIES,
+  INVESTIGATION_STATUSES,
+  type InvestigationDetail,
+  type InvestigationEvent
+} from '../../../lib/data/investigations';
+
+type StaffOption = {
+  id: string;
+  label: string;
+  email: string;
+};
+
+type InvestigationDetailClientProps = {
+  investigation: InvestigationDetail;
+  events: InvestigationEvent[];
+  staffOptions: StaffOption[];
+  canManage: boolean;
+};
+
+type PendingField =
+  | 'title'
+  | 'status'
+  | 'severity'
+  | 'assignee'
+  | 'summary'
+  | 'tags'
+  | 'note'
+  | null;
+
+function formatIsoDate(timestamp: string | null): string {
+  if (!timestamp) {
+    return '—';
+  }
+  const date = new Date(timestamp);
+  return date.toLocaleString('en-US', {
+    hour12: false,
+    timeZone: 'UTC'
+  });
+}
+
+function formatRelative(timestamp: string | null): string {
+  if (!timestamp) {
+    return '—';
+  }
+
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  const diffMinutes = Math.round(diffMs / (1000 * 60));
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  if (Math.abs(diffMinutes) < 60) {
+    return formatter.format(diffMinutes, 'minute');
+  }
+
+  const diffHours = Math.round(diffMinutes / 60);
+  if (Math.abs(diffHours) < 24) {
+    return formatter.format(diffHours, 'hour');
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return formatter.format(diffDays, 'day');
+}
+
+function renderMeta(meta: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(meta, null, 2);
+  } catch (error) {
+    console.warn('Failed to render event meta', error);
+    return '{}';
+  }
+}
+
+function computeTagInput(tags: string[]): string {
+  return tags.join(', ');
+}
+
+export default function InvestigationDetailClient({
+  investigation,
+  events,
+  staffOptions,
+  canManage
+}: InvestigationDetailClientProps) {
+  const router = useRouter();
+  const [state, setState] = useState(investigation);
+  const [timeline, setTimeline] = useState(events);
+  const [titleDraft, setTitleDraft] = useState(investigation.title);
+  const [summaryDraft, setSummaryDraft] = useState(investigation.summary ?? '');
+  const [tagsDraft, setTagsDraft] = useState(computeTagInput(investigation.tags));
+  const [noteDraft, setNoteDraft] = useState('');
+  const [pending, setPending] = useState<PendingField>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setState(investigation);
+    setTitleDraft(investigation.title);
+    setSummaryDraft(investigation.summary ?? '');
+    setTagsDraft(computeTagInput(investigation.tags));
+  }, [investigation]);
+
+  useEffect(() => {
+    setTimeline(events);
+  }, [events]);
+
+  const tagList = useMemo(() => state.tags, [state.tags]);
+
+  function parseTagsInput(value: string): string[] {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag, index, array) => tag.length > 0 && array.indexOf(tag) === index);
+  }
+
+  async function updateInvestigation(
+    payload: Partial<{ title: string; status: string; severity: string; assignedTo: string | null; summary: string | null; tags: string[] }>,
+    field: PendingField
+  ) {
+    if (!canManage) {
+      return;
+    }
+
+    setPending(field);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/investigations/${state.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        setError(text || 'Failed to update investigation');
+        return;
+      }
+
+      const json = (await response.json()) as {
+        investigation: InvestigationDetail;
+        events?: InvestigationEvent[];
+      };
+
+      setState(json.investigation);
+      setTitleDraft(json.investigation.title);
+      setSummaryDraft(json.investigation.summary ?? '');
+      setTagsDraft(computeTagInput(json.investigation.tags));
+      if (json.events && json.events.length) {
+        setTimeline((previous) => [...json.events!, ...previous]);
+      }
+      router.refresh();
+    } catch (updateError) {
+      console.error('Failed to update investigation', updateError);
+      setError('Unexpected error while updating investigation');
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function submitNote() {
+    const message = noteDraft.trim();
+    if (!message) {
+      return;
+    }
+
+    setPending('note');
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/investigations/${state.id}/events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ message })
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        setError(text || 'Failed to add note');
+        return;
+      }
+
+      const json = (await response.json()) as { event: InvestigationEvent };
+      setTimeline((previous) => [json.event, ...previous]);
+      setNoteDraft('');
+      router.refresh();
+    } catch (noteError) {
+      console.error('Failed to add note', noteError);
+      setError('Unexpected error while adding note');
+    } finally {
+      setPending(null);
+    }
+  }
+
+  function disabledTooltip() {
+    return canManage ? undefined : 'Requires investigator or security admin';
+  }
+
+  function resolveStaffLabel(id: string | null): string {
+    if (!id) {
+      return 'Unassigned';
+    }
+    const option = staffOptions.find((staff) => staff.id === id);
+    return option?.label ?? option?.email ?? 'Unknown';
+  }
+
+  return (
+    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 text-slate-100 shadow-2xl">
+      <header className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">Title</label>
+          <input
+            type="text"
+            value={titleDraft}
+            onChange={(event) => setTitleDraft(event.target.value)}
+            onBlur={() => {
+              const trimmed = titleDraft.trim();
+              if (trimmed && trimmed !== state.title) {
+                void updateInvestigation({ title: trimmed }, 'title');
+              } else {
+                setTitleDraft(state.title);
+              }
+            }}
+            disabled={!canManage || pending === 'title'}
+            title={disabledTooltip()}
+            className="w-full rounded-2xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-lg font-semibold text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+          />
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">Status</label>
+            <select
+              value={state.status}
+              disabled={!canManage || pending === 'status'}
+              title={disabledTooltip()}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== state.status) {
+                  void updateInvestigation({ status: value }, 'status');
+                }
+              }}
+              className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+            >
+              {INVESTIGATION_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status.replace('_', ' ')}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">Severity</label>
+            <select
+              value={state.severity}
+              disabled={!canManage || pending === 'severity'}
+              title={disabledTooltip()}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== state.severity) {
+                  void updateInvestigation({ severity: value }, 'severity');
+                }
+              }}
+              className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+            >
+              {INVESTIGATION_SEVERITIES.map((severity) => (
+                <option key={severity} value={severity}>
+                  {severity.replace('_', ' ')}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">Assignee</label>
+            <select
+              value={state.assignedTo.id ?? ''}
+              disabled={!canManage || pending === 'assignee'}
+              title={disabledTooltip()}
+              onChange={(event) => {
+                const value = event.target.value || null;
+                if ((value ?? null) !== (state.assignedTo.id ?? null)) {
+                  void updateInvestigation({ assignedTo: value }, 'assignee');
+                }
+              }}
+              className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+            >
+              <option value="">Unassigned</option>
+              {staffOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label} ({option.email})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">Opened by</label>
+            <div className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm text-slate-300">
+              {state.openedBy.displayName ?? state.openedBy.email ?? 'Unknown'}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <section className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-slate-100">Timeline</h2>
+            <span className="text-xs uppercase tracking-widest text-slate-500">Updated {formatRelative(state.updatedAt)}</span>
+          </div>
+          <div className="flex flex-col gap-4">
+            {timeline.map((event) => {
+              const actorName = event.actor.displayName ?? event.actor.email ?? 'System';
+              const initials = actorName
+                .split(/\s+/)
+                .map((part) => part.charAt(0))
+                .join('')
+                .slice(0, 2)
+                .toUpperCase();
+
+              return (
+                <article key={event.id} className="flex gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-700 bg-slate-900/70 text-sm font-semibold text-slate-200">
+                    {initials || '∅'}
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2">
+                    <div className="flex flex-col gap-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-semibold text-slate-100">{actorName}</span>
+                        <span className="text-xs uppercase tracking-widest text-slate-500">{event.kind.replace('_', ' ')}</span>
+                        <span className="text-xs text-slate-500">{formatRelative(event.createdAt)}</span>
+                      </div>
+                      {event.message && <p className="text-sm text-slate-200">{event.message}</p>}
+                    </div>
+                    {event.meta && Object.keys(event.meta).length > 0 && (
+                      <details className="rounded-xl border border-slate-800 bg-slate-900/60 p-3 text-xs">
+                        <summary className="cursor-pointer text-slate-400">Meta</summary>
+                        <pre className="mt-2 whitespace-pre-wrap break-words text-slate-300">{renderMeta(event.meta)}</pre>
+                      </details>
+                    )}
+                  </div>
+                </article>
+              );
+            })}
+
+            {timeline.length === 0 && (
+              <div className="rounded-2xl border border-dashed border-slate-800 bg-slate-950/60 p-6 text-center text-sm text-slate-400">
+                No timeline activity yet.
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Add note</h3>
+            <textarea
+              value={noteDraft}
+              onChange={(event) => setNoteDraft(event.target.value)}
+              placeholder="Leave context for the next responder"
+              rows={3}
+              className="mt-3 w-full rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+              disabled={!canManage || pending === 'note'}
+              title={disabledTooltip()}
+            />
+            <div className="mt-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => void submitNote()}
+                disabled={!canManage || pending === 'note' || !noteDraft.trim()}
+                className={clsx(
+                  'rounded-xl border px-4 py-2 text-sm font-semibold transition',
+                  !canManage
+                    ? 'cursor-not-allowed border-slate-800 bg-slate-900/60 text-slate-500'
+                    : pending === 'note'
+                      ? 'cursor-wait border-slate-700 bg-slate-800/60 text-slate-400'
+                      : 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100'
+                )}
+              >
+                {pending === 'note' ? 'Posting…' : 'Post note'}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="flex flex-col gap-6 rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-slate-200">
+          <section className="flex flex-col gap-2">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Summary</h3>
+            <textarea
+              value={summaryDraft}
+              onChange={(event) => setSummaryDraft(event.target.value)}
+              onBlur={() => {
+                const trimmed = summaryDraft.trim();
+                const canonical = state.summary ?? '';
+                if (trimmed !== canonical) {
+                  void updateInvestigation({ summary: trimmed || null }, 'summary');
+                }
+              }}
+              disabled={!canManage || pending === 'summary'}
+              title={disabledTooltip()}
+              rows={6}
+              placeholder="Document key findings, hypotheses, and next steps"
+              className="rounded-2xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+            />
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Tags</h3>
+            <input
+              type="text"
+              value={tagsDraft}
+              onChange={(event) => setTagsDraft(event.target.value)}
+              onBlur={() => {
+                const parsed = parseTagsInput(tagsDraft);
+                if (JSON.stringify(parsed) !== JSON.stringify(tagList)) {
+                  void updateInvestigation({ tags: parsed }, 'tags');
+                }
+              }}
+              disabled={!canManage || pending === 'tags'}
+              title={disabledTooltip()}
+              placeholder="malware, phishing"
+              className="rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:text-slate-500"
+            />
+            <div className="flex flex-wrap gap-2">
+              {tagList.map((tag) => (
+                <span key={tag} className="inline-flex items-center rounded-full border border-slate-700 bg-slate-900/60 px-2 py-0.5 text-xs text-slate-200">
+                  {tag}
+                </span>
+              ))}
+              {tagList.length === 0 && <span className="text-xs text-slate-500">No tags yet</span>}
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-1 text-xs text-slate-400">
+            <div className="flex items-center justify-between">
+              <span>Opened</span>
+              <span className="text-slate-200">{formatIsoDate(state.createdAt)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Updated</span>
+              <span className="text-slate-200">{formatIsoDate(state.updatedAt)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Assignee</span>
+              <span className="text-slate-200">{resolveStaffLabel(state.assignedTo.id ?? null)}</span>
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      {error && <p className="text-sm text-rose-300">{error}</p>}
+    </section>
+  );
+}

--- a/apps/console/app/investigations/components/InvestigationDetailClient.tsx
+++ b/apps/console/app/investigations/components/InvestigationDetailClient.tsx
@@ -3,12 +3,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
-import {
-  INVESTIGATION_SEVERITIES,
-  INVESTIGATION_STATUSES,
-  type InvestigationDetail,
-  type InvestigationEvent
-} from '../../../lib/data/investigations';
+import { INVESTIGATION_SEVERITIES, INVESTIGATION_STATUSES } from '../../../lib/investigations/constants';
+import type { InvestigationDetail, InvestigationEvent } from '../../../lib/data/investigations';
 
 type StaffOption = {
   id: string;

--- a/apps/console/app/investigations/components/NewInvestigationDialog.tsx
+++ b/apps/console/app/investigations/components/NewInvestigationDialog.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
-import { INVESTIGATION_SEVERITIES } from '../../../lib/data/investigations';
+import { INVESTIGATION_SEVERITIES } from '../../../lib/investigations/constants';
 
 type NewInvestigationDialogProps = {
   canManage: boolean;

--- a/apps/console/app/investigations/components/NewInvestigationDialog.tsx
+++ b/apps/console/app/investigations/components/NewInvestigationDialog.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import clsx from 'clsx';
+import { INVESTIGATION_SEVERITIES } from '../../../lib/data/investigations';
+
+type NewInvestigationDialogProps = {
+  canManage: boolean;
+};
+
+function normaliseTags(value: string): string[] {
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag, index, array) => tag.length > 0 && array.indexOf(tag) === index);
+}
+
+export default function NewInvestigationDialog({ canManage }: NewInvestigationDialogProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const severityOptions = useMemo(() => INVESTIGATION_SEVERITIES, []);
+
+  const closeDialog = useCallback(() => {
+    setOpen(false);
+    setSubmitting(false);
+    setError(null);
+    formRef.current?.reset();
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (submitting) {
+        return;
+      }
+
+      const form = event.currentTarget;
+      const formData = new FormData(form);
+      const title = (formData.get('title') as string | null)?.trim() ?? '';
+      const severity = (formData.get('severity') as string | null)?.trim().toLowerCase() ?? 'medium';
+      const summary = (formData.get('summary') as string | null)?.trim() ?? '';
+      const tagsInput = (formData.get('tags') as string | null)?.trim() ?? '';
+
+      if (!title) {
+        setError('Title is required.');
+        return;
+      }
+
+      if (!severityOptions.includes(severity as (typeof INVESTIGATION_SEVERITIES)[number])) {
+        setError('Invalid severity selection.');
+        return;
+      }
+
+      setSubmitting(true);
+      setError(null);
+
+      try {
+        const response = await fetch('/api/investigations', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            title,
+            severity,
+            summary: summary || undefined,
+            tags: normaliseTags(tagsInput)
+          })
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          setError(text || 'Failed to create investigation.');
+          setSubmitting(false);
+          return;
+        }
+
+        closeDialog();
+        router.refresh();
+      } catch (submitError) {
+        console.error('Failed to create investigation', submitError);
+        setError('Unexpected error creating investigation.');
+        setSubmitting(false);
+      }
+    },
+    [closeDialog, router, severityOptions, submitting]
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={!canManage}
+        title={canManage ? undefined : 'Requires investigator or security admin role'}
+        className={clsx(
+          'inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-semibold transition',
+          canManage
+            ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100'
+            : 'cursor-not-allowed border-slate-800 bg-slate-900/50 text-slate-500'
+        )}
+      >
+        + New investigation
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="w-full max-w-lg rounded-3xl border border-slate-800 bg-slate-950/90 p-6 text-slate-100 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-slate-100">New investigation</h2>
+              <button
+                type="button"
+                onClick={closeDialog}
+                className="rounded-full border border-transparent p-2 text-slate-400 transition hover:border-slate-700 hover:text-slate-200"
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+
+            <form ref={formRef} onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="title" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                  Title
+                </label>
+                <input
+                  id="title"
+                  name="title"
+                  type="text"
+                  required
+                  placeholder="Example: Suspicious login trail"
+                  className="rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="severity" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                    Severity
+                  </label>
+                  <select
+                    id="severity"
+                    name="severity"
+                    defaultValue="medium"
+                    className="rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  >
+                    {severityOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option.charAt(0).toUpperCase() + option.slice(1)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="tags" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                    Tags
+                  </label>
+                  <input
+                    id="tags"
+                    name="tags"
+                    type="text"
+                    placeholder="threat-intel, phishing"
+                    className="rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  />
+                  <p className="text-xs text-slate-500">Comma separated</p>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label htmlFor="summary" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                  Summary
+                </label>
+                <textarea
+                  id="summary"
+                  name="summary"
+                  rows={4}
+                  placeholder="What triggered this investigation?"
+                  className="rounded-2xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </div>
+
+              {error && <p className="text-sm text-rose-300">{error}</p>}
+
+              <div className="mt-2 flex items-center justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeDialog}
+                  className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/40"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className={clsx(
+                    'rounded-xl border px-4 py-2 text-sm font-semibold transition',
+                    submitting
+                      ? 'cursor-wait border-slate-700 bg-slate-800/60 text-slate-400'
+                      : 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100'
+                  )}
+                >
+                  {submitting ? 'Creating…' : 'Create investigation'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/console/app/investigations/page.tsx
+++ b/apps/console/app/investigations/page.tsx
@@ -1,67 +1,139 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { Suspense } from 'react';
+import clsx from 'clsx';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
 import { getStaffUser } from '../../lib/auth';
+import {
+  INVESTIGATION_SEVERITIES,
+  INVESTIGATION_STATUSES,
+  type InvestigationListItem
+} from '../../lib/data/investigations';
 import { listInvestigations } from '../../lib/data/investigations';
+import NewInvestigationDialog from './components/NewInvestigationDialog';
 
 export const metadata: Metadata = {
   title: 'Investigations | Torvus Console'
 };
 
-function formatUtc(timestamp: string | null): string {
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type ParsedFilters = {
+  statuses: string[];
+  severities: string[];
+  assigned: 'any' | 'me' | 'unassigned';
+  search: string;
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  triage: 'Triage',
+  in_progress: 'In progress',
+  closed: 'Closed'
+};
+
+const SEVERITY_LABELS: Record<string, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical'
+};
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function parseFilters(searchParams: SearchParams): ParsedFilters {
+  const statusParams = toArray(searchParams.status);
+  const severityParams = toArray(searchParams.severity);
+
+  const assignedParam = typeof searchParams.assigned === 'string' ? searchParams.assigned : 'any';
+  const assigned = assignedParam === 'me' || assignedParam === 'unassigned' ? assignedParam : 'any';
+
+  const search = typeof searchParams.q === 'string' ? searchParams.q : '';
+
+  return {
+    statuses: statusParams.map((status) => status.toLowerCase()),
+    severities: severityParams.map((severity) => severity.toLowerCase()),
+    assigned,
+    search
+  };
+}
+
+function formatRelativeTime(timestamp: string | null): string {
   if (!timestamp) {
     return '—';
   }
+
   const date = new Date(timestamp);
-  return date.toLocaleString('en-US', {
-    hour12: false,
-    timeZone: 'UTC'
-  });
-}
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  const diffMinutes = Math.round(diffMs / (1000 * 60));
 
-function PriorityPill({ priority }: { priority: number | null }) {
-  if (!priority || Number.isNaN(priority)) {
-    return (
-      <span className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-800/60 px-2 py-0.5 text-xs text-slate-200">
-        —
-      </span>
-    );
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  if (Math.abs(diffMinutes) < 60) {
+    return formatter.format(diffMinutes, 'minute');
   }
-  const palette = priority <= 2
-    ? 'border-rose-500/70 bg-rose-500/10 text-rose-200'
-    : priority === 3
-      ? 'border-amber-500/60 bg-amber-500/15 text-amber-200'
-      : 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200';
-  return (
-    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${palette}`}>
-      P{priority}
-    </span>
-  );
+
+  const diffHours = Math.round(diffMinutes / 60);
+  if (Math.abs(diffHours) < 24) {
+    return formatter.format(diffHours, 'hour');
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return formatter.format(diffDays, 'day');
 }
 
-function StatusBadge({ status }: { status: string | null }) {
-  const key = (status ?? 'unknown').toLowerCase();
-  const label = key === 'unknown' ? 'Unknown' : key.replace(/\b\w/g, (char) => char.toUpperCase());
+function StatusBadge({ status }: { status: string }) {
+  const key = status.toLowerCase();
   const palette: Record<string, string> = {
     open: 'border-sky-500/50 bg-sky-500/10 text-sky-200',
-    on_hold: 'border-amber-500/60 bg-amber-500/15 text-amber-200',
+    triage: 'border-amber-500/60 bg-amber-500/15 text-amber-200',
+    in_progress: 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200',
     closed: 'border-slate-700/70 bg-slate-800/60 text-slate-300'
   };
+
+  const label = STATUS_LABELS[key] ?? key;
   const className = palette[key] ?? 'border-slate-700/70 bg-slate-800/60 text-slate-200';
+
   return (
-    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${className}`}>
+    <span className={clsx('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold', className)}>
       {label}
     </span>
   );
 }
 
-function AssigneeChip({ email }: { email: string | null }) {
-  if (!email) {
+function SeverityBadge({ severity }: { severity: string }) {
+  const key = severity.toLowerCase();
+  const palette: Record<string, string> = {
+    low: 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200',
+    medium: 'border-sky-500/50 bg-sky-500/10 text-sky-200',
+    high: 'border-amber-500/60 bg-amber-500/15 text-amber-200',
+    critical: 'border-rose-500/70 bg-rose-500/10 text-rose-200'
+  };
+
+  const label = SEVERITY_LABELS[key] ?? key;
+  const className = palette[key] ?? 'border-slate-700/70 bg-slate-800/60 text-slate-200';
+
+  return (
+    <span className={clsx('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold', className)}>
+      {label}
+    </span>
+  );
+}
+
+function AssigneeChip({ assignee }: { assignee: InvestigationListItem['assignedTo'] }) {
+  if (!assignee?.id) {
     return <span className="text-xs text-slate-500">Unassigned</span>;
   }
+
   return (
     <span className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-800/60 px-2 py-0.5 text-xs text-slate-200">
-      {email}
+      {assignee.displayName ?? assignee.email ?? 'Unknown'}
     </span>
   );
 }
@@ -69,11 +141,11 @@ function AssigneeChip({ email }: { email: string | null }) {
 function InvestigationsSkeleton() {
   return (
     <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
-      <div className="flex items-center justify-between">
-        <div className="h-6 w-40 animate-pulse rounded-full bg-slate-800" />
-        <div className="h-6 w-24 animate-pulse rounded-full bg-slate-800" />
-      </div>
       <div className="flex flex-col gap-4">
+        <div className="h-10 w-48 animate-pulse rounded-full bg-slate-800" />
+        <div className="h-5 w-32 animate-pulse rounded-full bg-slate-800" />
+      </div>
+      <div className="flex flex-col gap-3">
         {[0, 1, 2].map((key) => (
           <div key={key} className="h-20 animate-pulse rounded-2xl bg-slate-800/60" />
         ))}
@@ -82,19 +154,29 @@ function InvestigationsSkeleton() {
   );
 }
 
-async function InvestigationsListSection() {
-  const investigations = await listInvestigations();
+async function InvestigationsListSection({
+  filters,
+  viewerId
+}: {
+  filters: ParsedFilters;
+  viewerId: string | null;
+}) {
+  const investigations = await listInvestigations({
+    filters,
+    viewerId,
+    limit: 100
+  });
 
   if (!investigations.length) {
     return (
       <section className="flex flex-col gap-4 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 text-slate-200 shadow-2xl">
         <header className="flex flex-col gap-1">
-          <h1 className="text-3xl font-semibold text-slate-100">Open investigations</h1>
-          <p className="text-sm text-slate-400">Track triage efforts assigned to Torvus operators.</p>
+          <h1 className="text-3xl font-semibold text-slate-100">Investigations</h1>
+          <p className="text-sm text-slate-400">Track case work across the Torvus incident queue.</p>
         </header>
         <div className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/70 p-8 text-center">
-          <h2 className="text-xl font-semibold text-slate-100">No open investigations</h2>
-          <p className="mt-2 text-sm text-slate-400">Inbound investigations will appear here once created.</p>
+          <h2 className="text-xl font-semibold text-slate-100">No investigations match your filters</h2>
+          <p className="mt-2 text-sm text-slate-400">Adjust the filters above or create a new investigation.</p>
         </div>
       </section>
     );
@@ -103,37 +185,9 @@ async function InvestigationsListSection() {
   return (
     <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 text-slate-200 shadow-2xl">
       <header className="flex flex-col gap-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Open investigations</h1>
-        <p className="text-sm text-slate-400">Track triage efforts assigned to Torvus operators.</p>
+        <h1 className="text-3xl font-semibold text-slate-100">Investigations</h1>
+        <p className="text-sm text-slate-400">Open, triage, and collaborate on Torvus case work.</p>
       </header>
-
-      <div className="flex flex-col gap-4 lg:hidden">
-        {investigations.map((item) => (
-          <article key={item.id} className="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <h2 className="text-lg font-semibold text-slate-100">{item.title}</h2>
-                <p className="text-xs text-slate-400">Updated {formatUtc(item.updatedAt)}</p>
-              </div>
-              <PriorityPill priority={item.priority} />
-            </div>
-            <dl className="mt-4 grid grid-cols-2 gap-3 text-xs text-slate-300">
-              <div>
-                <dt className="text-slate-500">Status</dt>
-                <dd className="mt-1 font-medium text-slate-200">
-                  <StatusBadge status={item.status} />
-                </dd>
-              </div>
-              <div>
-                <dt className="text-slate-500">Assignee</dt>
-                <dd className="mt-1">
-                  <AssigneeChip email={item.assigneeEmail} />
-                </dd>
-              </div>
-            </dl>
-          </article>
-        ))}
-      </div>
 
       <div className="hidden lg:block">
         <div className="overflow-hidden rounded-2xl border border-slate-800/60">
@@ -141,25 +195,29 @@ async function InvestigationsListSection() {
             <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
               <tr>
                 <th scope="col" className="px-6 py-3 font-semibold">Title</th>
-                <th scope="col" className="px-6 py-3 font-semibold">Priority</th>
                 <th scope="col" className="px-6 py-3 font-semibold">Status</th>
-                <th scope="col" className="px-6 py-3 font-semibold">Updated (UTC)</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Severity</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Updated</th>
                 <th scope="col" className="px-6 py-3 font-semibold">Assignee</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-800/60 text-slate-200">
               {investigations.map((item) => (
                 <tr key={item.id} className="transition hover:bg-slate-800/40">
-                  <td className="px-6 py-4 font-medium text-slate-100">{item.title}</td>
-                  <td className="px-6 py-4">
-                    <PriorityPill priority={item.priority} />
+                  <td className="px-6 py-4 font-medium text-slate-100">
+                    <Link href={`/investigations/${item.id}`} className="hover:text-emerald-300">
+                      {item.title}
+                    </Link>
                   </td>
                   <td className="px-6 py-4">
                     <StatusBadge status={item.status} />
                   </td>
-                  <td className="px-6 py-4 text-slate-300">{formatUtc(item.updatedAt)}</td>
                   <td className="px-6 py-4">
-                    <AssigneeChip email={item.assigneeEmail} />
+                    <SeverityBadge severity={item.severity} />
+                  </td>
+                  <td className="px-6 py-4 text-slate-300">{formatRelativeTime(item.updatedAt)}</td>
+                  <td className="px-6 py-4">
+                    <AssigneeChip assignee={item.assignedTo} />
                   </td>
                 </tr>
               ))}
@@ -167,11 +225,130 @@ async function InvestigationsListSection() {
           </table>
         </div>
       </div>
+
+      <div className="flex flex-col gap-4 lg:hidden">
+        {investigations.map((item) => (
+          <article key={item.id} className="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <Link href={`/investigations/${item.id}`} className="text-lg font-semibold text-slate-100 hover:text-emerald-300">
+                  {item.title}
+                </Link>
+                <p className="text-xs text-slate-400">Updated {formatRelativeTime(item.updatedAt)}</p>
+              </div>
+              <SeverityBadge severity={item.severity} />
+            </div>
+            <dl className="mt-4 grid grid-cols-2 gap-3 text-xs text-slate-300">
+              <div>
+                <dt className="text-slate-500">Status</dt>
+                <dd className="mt-1">
+                  <StatusBadge status={item.status} />
+                </dd>
+              </div>
+              <div>
+                <dt className="text-slate-500">Assignee</dt>
+                <dd className="mt-1">
+                  <AssigneeChip assignee={item.assignedTo} />
+                </dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }
 
-export default async function InvestigationsPage() {
+function FiltersForm({ filters }: { filters: ParsedFilters }) {
+  return (
+    <form method="get" className="flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 text-slate-200 lg:flex-row lg:items-end lg:justify-between">
+      <div className="grid gap-4 lg:grid-cols-3">
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-xs font-semibold uppercase tracking-widest text-slate-400">Status</legend>
+          <div className="flex flex-wrap gap-2">
+            {INVESTIGATION_STATUSES.map((status) => (
+              <label key={status} className="inline-flex items-center gap-2 text-sm text-slate-200">
+                <input
+                  type="checkbox"
+                  name="status"
+                  value={status}
+                  defaultChecked={filters.statuses.includes(status)}
+                  className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-400 focus:ring-emerald-500"
+                />
+                <span>{STATUS_LABELS[status] ?? status}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-xs font-semibold uppercase tracking-widest text-slate-400">Severity</legend>
+          <div className="flex flex-wrap gap-2">
+            {INVESTIGATION_SEVERITIES.map((severity) => (
+              <label key={severity} className="inline-flex items-center gap-2 text-sm text-slate-200">
+                <input
+                  type="checkbox"
+                  name="severity"
+                  value={severity}
+                  defaultChecked={filters.severities.includes(severity)}
+                  className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-400 focus:ring-emerald-500"
+                />
+                <span>{SEVERITY_LABELS[severity] ?? severity}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <div className="flex flex-col gap-2">
+          <label htmlFor="assigned" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Assignee
+          </label>
+          <select
+            id="assigned"
+            name="assigned"
+            defaultValue={filters.assigned}
+            className="rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            <option value="any">Anyone</option>
+            <option value="me">Assigned to me</option>
+            <option value="unassigned">Unassigned</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 lg:w-64">
+        <label htmlFor="q" className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+          Search title
+        </label>
+        <input
+          id="q"
+          name="q"
+          type="search"
+          defaultValue={filters.search}
+          placeholder="Phishing triage"
+          className="w-full rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className="rounded-xl border border-emerald-400/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+        >
+          Apply
+        </button>
+        <Link
+          href="/investigations"
+          className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/40"
+        >
+          Reset
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+export default async function InvestigationsPage({ searchParams }: { searchParams: SearchParams }) {
   const staffUser = await getStaffUser();
 
   if (!staffUser) {
@@ -182,10 +359,36 @@ export default async function InvestigationsPage() {
     );
   }
 
+  const hasViewPermission = staffUser.permissions.includes('investigations.view');
+
+  if (!hasViewPermission) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <AccessDeniedNotice variant="card" />
+        <p className="mt-4 max-w-md text-center text-sm text-slate-400">
+          Investigations require investigator, security administrator, or auditor privileges.
+        </p>
+      </div>
+    );
+  }
+
+  const filters = parseFilters(searchParams);
+  const canManage = staffUser.permissions.includes('investigations.manage');
+
   return (
-    <div className="flex flex-col gap-8 py-6">
+    <div className="flex flex-col gap-6 py-6">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Investigations</h1>
+          <p className="text-sm text-slate-400">Lightweight case tracking for Torvus responders.</p>
+        </div>
+        <NewInvestigationDialog canManage={canManage} />
+      </div>
+
+      <FiltersForm filters={filters} />
+
       <Suspense fallback={<InvestigationsSkeleton />}>
-        <InvestigationsListSection />
+        <InvestigationsListSection filters={filters} viewerId={staffUser.id} />
       </Suspense>
     </div>
   );

--- a/apps/console/app/investigations/page.tsx
+++ b/apps/console/app/investigations/page.tsx
@@ -4,12 +4,8 @@ import { Suspense } from 'react';
 import clsx from 'clsx';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
 import { getStaffUser } from '../../lib/auth';
-import {
-  INVESTIGATION_SEVERITIES,
-  INVESTIGATION_STATUSES,
-  type InvestigationListItem
-} from '../../lib/data/investigations';
-import { listInvestigations } from '../../lib/data/investigations';
+import { INVESTIGATION_SEVERITIES, INVESTIGATION_STATUSES } from '../../lib/investigations/constants';
+import { listInvestigations, type InvestigationListItem } from '../../lib/data/investigations';
 import NewInvestigationDialog from './components/NewInvestigationDialog';
 
 export const metadata: Metadata = {

--- a/apps/console/lib/analytics.ts
+++ b/apps/console/lib/analytics.ts
@@ -21,7 +21,7 @@ type NavItem = {
 const NAV_ITEMS: NavItem[] = [
   { href: '/overview', label: 'Overview', permission: 'metrics.view', group: 'Operations' },
   { href: '/alerts', label: 'Alerts', group: 'Operations' },
-  { href: '/investigations', label: 'Investigations', group: 'Operations' },
+  { href: '/investigations', label: 'Investigations', permission: 'investigations.view', group: 'Operations' },
   { href: '/releases', label: 'Releases', permission: 'releases.simulate', group: 'Operations' },
   { href: '/audit', label: 'Audit trail', permission: 'audit.read', group: 'Security' }
 ];

--- a/apps/console/lib/data/investigations.ts
+++ b/apps/console/lib/data/investigations.ts
@@ -1,70 +1,244 @@
 import { createSupabaseServiceRoleClient } from '../supabase';
 
-type InvestigationRow = {
-  id: string;
-  created_at: string | null;
-  updated_at: string | null;
-  title: string | null;
-  priority: number | null;
-  status: string | null;
-  assignee_email: string | null;
+export const INVESTIGATION_STATUSES = ['open', 'triage', 'in_progress', 'closed'] as const;
+export const INVESTIGATION_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+
+export type InvestigationStatus = (typeof INVESTIGATION_STATUSES)[number];
+export type InvestigationSeverity = (typeof INVESTIGATION_SEVERITIES)[number];
+
+export type InvestigationUserRef = {
+  id: string | null;
+  email: string | null;
+  displayName: string | null;
 };
 
 export type InvestigationListItem = {
   id: string;
+  title: string;
+  status: InvestigationStatus;
+  severity: InvestigationSeverity;
   createdAt: string | null;
   updatedAt: string | null;
-  title: string;
-  priority: number | null;
-  status: string | null;
-  assigneeEmail: string | null;
+  summary: string | null;
+  tags: string[];
+  openedBy: InvestigationUserRef;
+  assignedTo: InvestigationUserRef;
 };
 
-function normaliseInvestigation(row: InvestigationRow): InvestigationListItem {
+export type InvestigationDetail = InvestigationListItem;
+
+export type InvestigationEvent = {
+  id: string;
+  investigationId: string;
+  createdAt: string | null;
+  actor: InvestigationUserRef;
+  kind: 'note' | 'status_change' | 'assignment_change' | 'attachment';
+  message: string | null;
+  meta: Record<string, unknown>;
+};
+
+type InvestigationListRow = {
+  id: string;
+  title: string | null;
+  status: string | null;
+  severity: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  summary: string | null;
+  tags: string[] | null;
+  opened_by: string | null;
+  opened_by_email: string | null;
+  opened_by_display_name: string | null;
+  assigned_to: string | null;
+  assigned_to_email: string | null;
+  assigned_to_display_name: string | null;
+};
+
+type InvestigationEventRow = {
+  id: string;
+  investigation_id: string;
+  created_at: string | null;
+  actor_user_id: string | null;
+  kind: 'note' | 'status_change' | 'assignment_change' | 'attachment';
+  message: string | null;
+  meta: Record<string, unknown> | null;
+  actor_email: string | null;
+  actor_display_name: string | null;
+};
+
+type InvestigationListFilters = {
+  statuses?: string[];
+  severities?: string[];
+  assigned?: 'any' | 'me' | 'unassigned';
+  search?: string;
+};
+
+function escapeILike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function normaliseUserRef(
+  id: string | null,
+  email: string | null,
+  displayName: string | null
+): InvestigationUserRef {
+  if (!id && !email && !displayName) {
+    return { id: null, email: null, displayName: null };
+  }
+
   return {
-    id: row.id,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    title: row.title ?? 'Untitled investigation',
-    priority: row.priority,
-    status: row.status,
-    assigneeEmail: row.assignee_email
+    id,
+    email: email ? email.toLowerCase() : null,
+    displayName: displayName ?? email ?? null
   };
 }
 
-function coerceLimit(limit: number | undefined, fallback: number): number {
-  if (!Number.isFinite(limit ?? NaN)) {
-    return fallback;
-  }
-  const value = Math.floor(limit ?? fallback);
-  if (value <= 0) {
-    return fallback;
-  }
-  return value;
+function normaliseInvestigation(row: InvestigationListRow): InvestigationDetail {
+  const status = (row.status ?? 'open').toLowerCase();
+  const severity = (row.severity ?? 'medium').toLowerCase();
+
+  return {
+    id: row.id,
+    title: row.title?.trim() ? row.title.trim() : 'Untitled investigation',
+    status: INVESTIGATION_STATUSES.includes(status as InvestigationStatus)
+      ? (status as InvestigationStatus)
+      : 'open',
+    severity: INVESTIGATION_SEVERITIES.includes(severity as InvestigationSeverity)
+      ? (severity as InvestigationSeverity)
+      : 'medium',
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    summary: row.summary ?? null,
+    tags: Array.isArray(row.tags) ? row.tags : [],
+    openedBy: normaliseUserRef(row.opened_by, row.opened_by_email, row.opened_by_display_name),
+    assignedTo: normaliseUserRef(row.assigned_to, row.assigned_to_email, row.assigned_to_display_name)
+  };
 }
 
-export async function listInvestigations(limit = 50): Promise<InvestigationListItem[]> {
-  const supabase = createSupabaseServiceRoleClient();
-  const finalLimit = coerceLimit(limit, 50);
+function normaliseEvent(row: InvestigationEventRow): InvestigationEvent {
+  return {
+    id: row.id,
+    investigationId: row.investigation_id,
+    createdAt: row.created_at,
+    actor: normaliseUserRef(row.actor_user_id, row.actor_email, row.actor_display_name),
+    kind: row.kind,
+    message: row.message,
+    meta: row.meta ?? {}
+  };
+}
 
-  const { data, error } = await (supabase.from('investigations') as any)
-    .select('id, created_at, updated_at, title, priority, status, assignee_email')
-    .eq('status', 'open')
-    .order('priority', { ascending: true, nullsFirst: false })
+export async function listInvestigations({
+  limit = 50,
+  filters = {},
+  viewerId = null
+}: {
+  limit?: number;
+  filters?: InvestigationListFilters;
+  viewerId?: string | null;
+} = {}): Promise<InvestigationListItem[]> {
+  const supabase = createSupabaseServiceRoleClient();
+  const finalLimit = Number.isFinite(limit) && limit! > 0 ? Math.floor(limit!) : 50;
+
+  const query = (supabase.from('v_investigations_list') as any)
+    .select(
+      `id, title, status, severity, created_at, updated_at, summary, tags, opened_by, opened_by_email, opened_by_display_name, assigned_to, assigned_to_email, assigned_to_display_name`
+    )
     .order('updated_at', { ascending: false, nullsFirst: false })
     .limit(finalLimit);
 
+  if (filters.statuses && filters.statuses.length) {
+    const validStatuses = filters.statuses
+      .map((status) => status.toLowerCase())
+      .filter((status) => INVESTIGATION_STATUSES.includes(status as InvestigationStatus));
+    if (validStatuses.length) {
+      query.in('status', validStatuses);
+    }
+  }
+
+  if (filters.severities && filters.severities.length) {
+    const validSeverities = filters.severities
+      .map((severity) => severity.toLowerCase())
+      .filter((severity) => INVESTIGATION_SEVERITIES.includes(severity as InvestigationSeverity));
+    if (validSeverities.length) {
+      query.in('severity', validSeverities);
+    }
+  }
+
+  if (filters.assigned === 'me') {
+    if (viewerId) {
+      query.eq('assigned_to', viewerId);
+    } else {
+      query.eq('assigned_to', '__never__');
+    }
+  } else if (filters.assigned === 'unassigned') {
+    query.is('assigned_to', null);
+  }
+
+  if (filters.search && filters.search.trim()) {
+    const term = `%${escapeILike(filters.search.trim())}%`;
+    query.ilike('title', term);
+  }
+
+  const { data, error } = await query;
+
   if (error) {
     if (error.code === '42P01') {
-      console.warn('[investigations] investigations table missing, returning empty result');
+      console.warn('[investigations] table missing, returning empty list');
       return [];
     }
     console.error('[investigations] failed to list investigations', error);
     return [];
   }
 
-  const rows = (data as InvestigationRow[] | null) ?? [];
+  const rows = (data as InvestigationListRow[] | null) ?? [];
   return rows.map(normaliseInvestigation);
+}
+
+export async function getInvestigationById(id: string): Promise<InvestigationDetail | null> {
+  const supabase = createSupabaseServiceRoleClient();
+
+  const { data, error } = await (supabase.from('v_investigations_list') as any)
+    .select(
+      `id, title, status, severity, created_at, updated_at, summary, tags, opened_by, opened_by_email, opened_by_display_name, assigned_to, assigned_to_email, assigned_to_display_name`
+    )
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === '42P01') {
+      console.warn('[investigations] table missing when fetching detail');
+      return null;
+    }
+    console.error('[investigations] failed to load investigation', error);
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return normaliseInvestigation(data as InvestigationListRow);
+}
+
+export async function listInvestigationEvents(investigationId: string): Promise<InvestigationEvent[]> {
+  const supabase = createSupabaseServiceRoleClient();
+
+  const { data, error } = await (supabase.from('investigation_events_with_actor') as any)
+    .select('id, investigation_id, created_at, actor_user_id, kind, message, meta, actor_email, actor_display_name')
+    .eq('investigation_id', investigationId)
+    .order('created_at', { ascending: false, nullsFirst: false });
+
+  if (error) {
+    if (error.code === '42P01') {
+      console.warn('[investigations] events table missing, returning empty timeline');
+      return [];
+    }
+    console.error('[investigations] failed to load investigation events', error);
+    throw error;
+  }
+
+  const rows = (data as InvestigationEventRow[] | null) ?? [];
+  return rows.map(normaliseEvent);
 }
 
 export async function countInvestigations(): Promise<number> {
@@ -72,7 +246,7 @@ export async function countInvestigations(): Promise<number> {
 
   const { count, error } = await (supabase.from('investigations') as any)
     .select('id', { count: 'exact', head: true })
-    .eq('status', 'open');
+    .neq('status', 'closed');
 
   if (error) {
     if (error.code === '42P01') {

--- a/apps/console/lib/data/investigations.ts
+++ b/apps/console/lib/data/investigations.ts
@@ -1,10 +1,10 @@
 import { createSupabaseServiceRoleClient } from '../supabase';
-
-export const INVESTIGATION_STATUSES = ['open', 'triage', 'in_progress', 'closed'] as const;
-export const INVESTIGATION_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
-
-export type InvestigationStatus = (typeof INVESTIGATION_STATUSES)[number];
-export type InvestigationSeverity = (typeof INVESTIGATION_SEVERITIES)[number];
+import {
+  INVESTIGATION_SEVERITIES,
+  INVESTIGATION_STATUSES,
+  type InvestigationSeverity,
+  type InvestigationStatus
+} from '../investigations/constants';
 
 export type InvestigationUserRef = {
   id: string | null;

--- a/apps/console/lib/investigations/constants.ts
+++ b/apps/console/lib/investigations/constants.ts
@@ -1,0 +1,5 @@
+export const INVESTIGATION_STATUSES = ['open', 'triage', 'in_progress', 'closed'] as const;
+export const INVESTIGATION_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+
+export type InvestigationStatus = (typeof INVESTIGATION_STATUSES)[number];
+export type InvestigationSeverity = (typeof INVESTIGATION_SEVERITIES)[number];

--- a/apps/console/lib/rbac.ts
+++ b/apps/console/lib/rbac.ts
@@ -1,4 +1,10 @@
-export type RoleKey = 'viewer' | 'auditor' | 'operator' | 'security_admin' | 'break_glass';
+export type RoleKey =
+  | 'viewer'
+  | 'auditor'
+  | 'operator'
+  | 'investigator'
+  | 'security_admin'
+  | 'break_glass';
 
 export type PermissionKey =
   | 'metrics.view'
@@ -7,7 +13,9 @@ export type PermissionKey =
   | 'releases.simulate'
   | 'releases.execute'
   | 'policy.edit'
-  | 'staff.manage';
+  | 'staff.manage'
+  | 'investigations.view'
+  | 'investigations.manage';
 
 export interface StaffSubject {
   id: string;
@@ -16,8 +24,9 @@ export interface StaffSubject {
 
 export const ROLE_PERMISSIONS: Record<RoleKey, PermissionKey[]> = {
   viewer: ['metrics.view', 'audit.read'],
-  auditor: ['metrics.view', 'audit.read', 'audit.export'],
+  auditor: ['metrics.view', 'audit.read', 'audit.export', 'investigations.view'],
   operator: ['metrics.view', 'audit.read', 'releases.simulate'],
+  investigator: ['metrics.view', 'audit.read', 'investigations.view', 'investigations.manage'],
   security_admin: [
     'metrics.view',
     'audit.read',
@@ -25,7 +34,9 @@ export const ROLE_PERMISSIONS: Record<RoleKey, PermissionKey[]> = {
     'releases.simulate',
     'releases.execute',
     'policy.edit',
-    'staff.manage'
+    'staff.manage',
+    'investigations.view',
+    'investigations.manage'
   ],
   break_glass: [
     'metrics.view',
@@ -34,7 +45,9 @@ export const ROLE_PERMISSIONS: Record<RoleKey, PermissionKey[]> = {
     'releases.simulate',
     'releases.execute',
     'policy.edit',
-    'staff.manage'
+    'staff.manage',
+    'investigations.view',
+    'investigations.manage'
   ]
 };
 

--- a/apps/console/tests/rbac.guard.test.ts
+++ b/apps/console/tests/rbac.guard.test.ts
@@ -17,12 +17,21 @@ describe('RBAC guard', () => {
     const permissions = ROLE_PERMISSIONS.auditor;
     expect(hasPermission(permissions, 'audit.export')).toBe(true);
     expect(hasPermission(permissions, 'releases.simulate')).toBe(false);
+    expect(hasPermission(permissions, 'investigations.view')).toBe(true);
+    expect(hasPermission(permissions, 'investigations.manage')).toBe(false);
   });
 
   it('operator can simulate but not execute releases', () => {
     const permissions = ROLE_PERMISSIONS.operator;
     expect(hasPermission(permissions, 'releases.simulate')).toBe(true);
     expect(hasPermission(permissions, 'releases.execute')).toBe(false);
+  });
+
+  it('investigator can manage investigations but lacks staff admin rights', () => {
+    const permissions = ROLE_PERMISSIONS.investigator;
+    expect(hasPermission(permissions, 'investigations.view')).toBe(true);
+    expect(hasPermission(permissions, 'investigations.manage')).toBe(true);
+    expect(hasPermission(permissions, 'staff.manage')).toBe(false);
   });
 
   it('security_admin inherits all permissions including staff.manage', () => {

--- a/supabase/migrations/20250924_investigations.sql
+++ b/supabase/migrations/20250924_investigations.sql
@@ -1,0 +1,212 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.investigations (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  title text not null,
+  status text not null default 'open' check (status in ('open','triage','in_progress','closed')),
+  severity text not null default 'medium' check (severity in ('low','medium','high','critical')),
+  opened_by uuid not null references auth.users(id) on delete set null,
+  assigned_to uuid references auth.users(id) on delete set null,
+  tags text[] not null default '{}',
+  summary text
+);
+
+create table if not exists public.investigation_events (
+  id uuid primary key default gen_random_uuid(),
+  investigation_id uuid not null references public.investigations(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  actor_user_id uuid references public.staff_users(user_id) on delete set null,
+  kind text not null check (kind in ('note','status_change','assignment_change','attachment')),
+  message text,
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_investigations_updated_at_desc on public.investigations (updated_at desc);
+create index if not exists idx_investigation_events_investigation_created_desc on public.investigation_events (investigation_id, created_at desc);
+
+create or replace function public.set_investigations_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_investigations_set_updated_at on public.investigations;
+create trigger trg_investigations_set_updated_at
+before update on public.investigations
+for each row
+execute function public.set_investigations_updated_at();
+
+create or replace function public.touch_investigation_on_event()
+returns trigger
+language plpgsql
+as $$
+begin
+  update public.investigations
+     set updated_at = now()
+   where id = coalesce(new.investigation_id, old.investigation_id);
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_investigation_events_touch on public.investigation_events;
+create trigger trg_investigation_events_touch
+after insert or update on public.investigation_events
+for each row
+execute function public.touch_investigation_on_event();
+
+alter table public.investigations enable row level security;
+alter table public.investigation_events enable row level security;
+
+drop policy if exists investigations_select_roles on public.investigations;
+drop policy if exists investigations_manage_roles on public.investigations;
+drop policy if exists investigations_insert_roles on public.investigations;
+
+drop policy if exists investigation_events_select_roles on public.investigation_events;
+drop policy if exists investigation_events_insert_roles on public.investigation_events;
+
+create policy investigations_select_roles on public.investigations
+for select
+to authenticated
+using (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator','auditor'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+);
+
+create policy investigations_insert_roles on public.investigations
+for insert
+to authenticated
+with check (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+);
+
+create policy investigations_manage_roles on public.investigations
+for update
+to authenticated
+using (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+)
+with check (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+);
+
+create policy investigation_events_select_roles on public.investigation_events
+for select
+to authenticated
+using (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator','auditor'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+);
+
+create policy investigation_events_insert_roles on public.investigation_events
+for insert
+to authenticated
+with check (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.staff_users su
+    join public.staff_role_members srm on srm.user_id = su.user_id
+    join public.staff_roles sr on sr.id = srm.role_id
+    where sr.name = any(array['security_admin','investigator'])
+      and (
+        (auth.uid() is not null and su.user_id = auth.uid())
+        or (public.current_request_email() is not null and su.email = public.current_request_email())
+      )
+  )
+);
+
+create or replace view public.v_investigations_list as
+select
+  inv.id,
+  inv.created_at,
+  inv.updated_at,
+  inv.title,
+  inv.status,
+  inv.severity,
+  inv.summary,
+  inv.tags,
+  inv.opened_by,
+  opener.email as opened_by_email,
+  opener.display_name as opened_by_display_name,
+  inv.assigned_to,
+  assignee.email as assigned_to_email,
+  assignee.display_name as assigned_to_display_name
+from public.investigations inv
+left join public.staff_users opener on opener.user_id = inv.opened_by
+left join public.staff_users assignee on assignee.user_id = inv.assigned_to;
+
+create or replace view public.investigation_events_with_actor as
+select
+  ev.id,
+  ev.investigation_id,
+  ev.created_at,
+  ev.actor_user_id,
+  ev.kind,
+  ev.message,
+  ev.meta,
+  actor.email as actor_email,
+  actor.display_name as actor_display_name
+from public.investigation_events ev
+left join public.staff_users actor on actor.user_id = ev.actor_user_id;
+
+comment on view public.v_investigations_list is 'Investigation list with staff display metadata';
+comment on view public.investigation_events_with_actor is 'Investigation events joined with staff display metadata';

--- a/supabase/seed/20250924_seed_investigations.sql
+++ b/supabase/seed/20250924_seed_investigations.sql
@@ -1,0 +1,148 @@
+with staff_ordered as (
+  select user_id, row_number() over (order by created_at) as rn
+  from public.staff_users
+),
+open_seed as (
+  select
+    (select user_id from staff_ordered where rn = 1) as opened_by,
+    (select user_id from staff_ordered where rn = 2) as assigned_to
+),
+progress_seed as (
+  select
+    coalesce((select user_id from staff_ordered where rn = 2), (select user_id from staff_ordered where rn = 1)) as opened_by,
+    coalesce((select user_id from staff_ordered where rn = 3), (select user_id from staff_ordered where rn = 1)) as assigned_to
+),
+closed_seed as (
+  select
+    coalesce((select user_id from staff_ordered where rn = 3), (select user_id from staff_ordered where rn = 1)) as opened_by
+)
+insert into public.investigations (id, title, status, severity, opened_by, assigned_to, tags, summary)
+select
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0001'::uuid,
+  'Endpoint malware triage',
+  'open',
+  'high',
+  open_seed.opened_by,
+  open_seed.assigned_to,
+  array['endpoint','malware'],
+  'Indicators of compromise detected on workstation T-445.'
+from open_seed
+where open_seed.opened_by is not null
+on conflict (id) do nothing;
+
+with staff_ordered as (
+  select user_id, row_number() over (order by created_at) as rn
+  from public.staff_users
+),
+progress_seed as (
+  select
+    coalesce((select user_id from staff_ordered where rn = 2), (select user_id from staff_ordered where rn = 1)) as opened_by,
+    coalesce((select user_id from staff_ordered where rn = 3), (select user_id from staff_ordered where rn = 1)) as assigned_to
+)
+insert into public.investigations (id, title, status, severity, opened_by, assigned_to, tags, summary)
+select
+  'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbb0002'::uuid,
+  'Suspicious access review',
+  'in_progress',
+  'medium',
+  progress_seed.opened_by,
+  progress_seed.assigned_to,
+  array['access','iam'],
+  'Reviewing anomalous Okta session originating from foreign ASN.'
+from progress_seed
+where progress_seed.opened_by is not null
+on conflict (id) do nothing;
+
+with staff_ordered as (
+  select user_id, row_number() over (order by created_at) as rn
+  from public.staff_users
+),
+closed_seed as (
+  select
+    coalesce((select user_id from staff_ordered where rn = 3), (select user_id from staff_ordered where rn = 1)) as opened_by
+)
+insert into public.investigations (id, title, status, severity, opened_by, assigned_to, tags, summary)
+select
+  'cccccccc-cccc-4ccc-8ccc-cccccccc0003'::uuid,
+  'Vendor phishing follow-up',
+  'closed',
+  'low',
+  closed_seed.opened_by,
+  null,
+  array['phishing','vendor'],
+  'Confirmed vendor simulation; case closed with awareness reminder.'
+from closed_seed
+where closed_seed.opened_by is not null
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0101'::uuid,
+  inv.id,
+  inv.opened_by,
+  'note',
+  'Initial containment steps executed: host isolated from network.',
+  jsonb_build_object('seed', true, 'order', 1)
+from public.investigations inv
+where inv.id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0001'
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0102'::uuid,
+  inv.id,
+  coalesce(inv.assigned_to, inv.opened_by),
+  'note',
+  'Collected memory image for malware triage. Awaiting sandbox verdict.',
+  jsonb_build_object('seed', true, 'order', 2)
+from public.investigations inv
+where inv.id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0001'
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbb0201'::uuid,
+  inv.id,
+  inv.opened_by,
+  'note',
+  'Coordinated with IAM to rotate credentials and force sign-out.',
+  jsonb_build_object('seed', true, 'order', 1)
+from public.investigations inv
+where inv.id = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbb0002'
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbb0202'::uuid,
+  inv.id,
+  coalesce(inv.assigned_to, inv.opened_by),
+  'note',
+  'Awaiting geo-verification from user before closing access exception.',
+  jsonb_build_object('seed', true, 'order', 2)
+from public.investigations inv
+where inv.id = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbb0002'
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'cccccccc-cccc-4ccc-8ccc-cccccccc0301'::uuid,
+  inv.id,
+  inv.opened_by,
+  'note',
+  'Confirmed simulated phishing campaign. No compromise observed.',
+  jsonb_build_object('seed', true, 'order', 1)
+from public.investigations inv
+where inv.id = 'cccccccc-cccc-4ccc-8ccc-cccccccc0003'
+on conflict (id) do nothing;
+
+insert into public.investigation_events (id, investigation_id, actor_user_id, kind, message, meta)
+select
+  'cccccccc-cccc-4ccc-8ccc-cccccccc0302'::uuid,
+  inv.id,
+  inv.opened_by,
+  'note',
+  'Closed case after notifying vendor security contact.',
+  jsonb_build_object('seed', true, 'order', 2)
+from public.investigations inv
+where inv.id = 'cccccccc-cccc-4ccc-8ccc-cccccccc0003'
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- add investigations tables, triggers, row-level security policies, and seed data
- expose investigations REST endpoints with audit logging and timeline event support
- build investigations list and detail UIs with creation flow, assignment, status, severity, tags, and notes

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68cfe2c61dac832db3b3e75ee4aa1e4d