### PR TITLE
feat: add profile personal access tokens

### DIFF
--- a/apps/console/app/api/self/pats/[id]/revoke/route.ts
+++ b/apps/console/app/api/self/pats/[id]/revoke/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getSelf } from '../../../../../../lib/self';
+import { revokePat } from '../../../../../../server/pat';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: Request,
+  context: { params: { id?: string } }
+) {
+  const profile = await getSelf(request);
+  if (!profile) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const param = context.params.id;
+  const id = Array.isArray(param) ? param[0] : param;
+  if (!id) {
+    return new Response('token id required', { status: 400 });
+  }
+
+  try {
+    const row = await revokePat(id, profile.user_id);
+    if (!row) {
+      return new Response('not found', { status: 404 });
+    }
+
+    return NextResponse.json(row);
+  } catch (error) {
+    console.error('failed to revoke personal access token', error);
+    return new Response('failed to revoke token', { status: 500 });
+  }
+}

--- a/apps/console/app/api/self/pats/route.ts
+++ b/apps/console/app/api/self/pats/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { getSelf } from '../../../../lib/self';
+import { createPat, listPats } from '../../../../server/pat';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_SCOPES = new Set(['read', 'write']);
+
+function parseScopes(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const filtered = value
+    .map((scope) => (typeof scope === 'string' ? scope.trim() : ''))
+    .filter((scope) => VALID_SCOPES.has(scope));
+
+  return filtered.length ? Array.from(new Set(filtered)) : null;
+}
+
+function parseExpiry(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Date(timestamp);
+}
+
+export async function GET(request: Request) {
+  const profile = await getSelf(request);
+  if (!profile) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  try {
+    const tokens = await listPats(profile.user_id);
+    return NextResponse.json(tokens);
+  } catch (error) {
+    console.error('failed to list personal access tokens', error);
+    return new Response('failed to list tokens', { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const profile = await getSelf(request);
+  if (!profile) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return new Response('invalid json body', { status: 400 });
+  }
+
+  const name = typeof (payload as any)?.name === 'string' ? (payload as any).name.trim() : '';
+  if (!name) {
+    return new Response('name is required', { status: 400 });
+  }
+
+  if (name.length > 200) {
+    return new Response('name is too long', { status: 400 });
+  }
+
+  const parsedScopes = parseScopes((payload as any)?.scopes);
+  const parsedExpiry = parseExpiry((payload as any)?.expires_at);
+
+  try {
+    const result = await createPat(profile.user_id, name, parsedScopes ?? undefined, parsedExpiry ?? undefined);
+    return NextResponse.json({ token: result.token, row: result.row });
+  } catch (error: any) {
+    console.error('failed to create personal access token', error);
+
+    if (error && typeof error === 'object' && 'code' in error && error.code === '23505') {
+      return new Response('duplicate token name', { status: 409 });
+    }
+
+    return new Response('failed to create token', { status: 500 });
+  }
+}

--- a/apps/console/app/api/self/route.ts
+++ b/apps/console/app/api/self/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getSelf } from '../../../lib/self';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  try {
+    const profile = await getSelf(request);
+    if (!profile) {
+      return new Response('unauthorized', { status: 401 });
+    }
+
+    return NextResponse.json(profile);
+  } catch (error) {
+    console.error('failed to load self profile', error);
+    return new Response('failed to resolve profile', { status: 500 });
+  }
+}

--- a/apps/console/app/profile/PersonalAccessTokensPanel.tsx
+++ b/apps/console/app/profile/PersonalAccessTokensPanel.tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+
+export type PersonalAccessToken = {
+  id: string;
+  user_id: string;
+  name: string;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+  revoked: boolean;
+};
+
+const SCOPE_LABELS: Record<string, string> = {
+  read: 'Read',
+  write: 'Write'
+};
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+function buildExpiryPayload(value: string): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Date inputs return YYYY-MM-DD; normalise to midnight UTC.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return new Date(`${trimmed}T00:00:00Z`).toISOString();
+  }
+
+  const timestamp = Date.parse(trimmed);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Date(timestamp).toISOString();
+}
+
+function TokenSecretBanner({ secret, onDismiss }: { secret: string; onDismiss: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(secret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('failed to copy personal access token', error);
+    }
+  }, [secret]);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-amber-100">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold">Copy this token now</span>
+        <span className="text-sm text-amber-200/80">
+          This secret will only be shown once. Store it securely in your password manager.
+        </span>
+      </div>
+      <div className="flex flex-col gap-2 rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-50 sm:flex-row sm:items-center sm:justify-between">
+        <code className="truncate font-mono text-xs sm:text-sm">{secret}</code>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded-full border border-amber-400/40 bg-amber-400/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-100 transition hover:border-amber-300 hover:bg-amber-300/30"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-full border border-transparent px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-200 transition hover:text-amber-100"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ScopesList({ scopes }: { scopes: string[] }) {
+  const uniqueScopes = useMemo(() => Array.from(new Set(scopes)), [scopes]);
+
+  if (!uniqueScopes.length) {
+    return <span className="text-xs text-slate-400">Default (read, write)</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {uniqueScopes.map((scope) => (
+        <span
+          key={scope}
+          className="inline-flex items-center rounded-full border border-slate-600/70 bg-slate-800/70 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-slate-200"
+        >
+          {SCOPE_LABELS[scope] ?? scope}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function PersonalAccessTokensPanel() {
+  const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [scopeRead, setScopeRead] = useState(true);
+  const [scopeWrite, setScopeWrite] = useState(true);
+  const [expiry, setExpiry] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [creationError, setCreationError] = useState<string | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTokens() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/self/pats', { cache: 'no-store' });
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || 'failed to load tokens');
+        }
+        const data = (await response.json()) as PersonalAccessToken[];
+        if (!cancelled) {
+          setTokens(data);
+        }
+      } catch (loadError) {
+        console.error('failed to load personal access tokens', loadError);
+        if (!cancelled) {
+          setError('Unable to load personal access tokens. Refresh to try again.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadTokens();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const resetForm = useCallback(() => {
+    setName('');
+    setScopeRead(true);
+    setScopeWrite(true);
+    setExpiry('');
+    setCreationError(null);
+  }, []);
+
+  const handleCreate = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (creating) {
+        return;
+      }
+
+      setCreating(true);
+      setCreationError(null);
+
+      const selectedScopes: string[] = [];
+      if (scopeRead) {
+        selectedScopes.push('read');
+      }
+      if (scopeWrite) {
+        selectedScopes.push('write');
+      }
+
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        setCreationError('Name is required.');
+        setCreating(false);
+        return;
+      }
+
+      const payload: Record<string, unknown> = {
+        name: trimmedName
+      };
+
+      if (selectedScopes.length && selectedScopes.length < 2) {
+        payload.scopes = selectedScopes;
+      } else if (!selectedScopes.length) {
+        payload.scopes = [];
+      }
+
+      const expiresPayload = buildExpiryPayload(expiry);
+      if (expiry && !expiresPayload) {
+        setCreationError('Expiry date is invalid.');
+        setCreating(false);
+        return;
+      }
+
+      if (expiresPayload) {
+        payload.expires_at = expiresPayload;
+      }
+
+      try {
+        const response = await fetch('/api/self/pats', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || 'failed to create token');
+        }
+
+        const result = (await response.json()) as { token: string; row: PersonalAccessToken };
+        setTokens((previous) => [result.row, ...previous.filter((token) => token.id !== result.row.id)]);
+        setSecret(result.token);
+        setModalOpen(false);
+        resetForm();
+      } catch (createError) {
+        console.error('failed to create personal access token', createError);
+        setCreationError(
+          createError instanceof Error
+            ? createError.message
+            : 'Unable to create token. Please try again.'
+        );
+      } finally {
+        setCreating(false);
+      }
+    },
+    [creating, expiry, name, resetForm, scopeRead, scopeWrite]
+  );
+
+  const handleRevoke = useCallback(async (id: string) => {
+    try {
+      setError(null);
+      const response = await fetch(`/api/self/pats/${encodeURIComponent(id)}/revoke`, { method: 'POST' });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'failed to revoke token');
+      }
+      const row = (await response.json()) as PersonalAccessToken;
+      setTokens((previous) => previous.map((token) => (token.id === row.id ? row : token)));
+    } catch (revokeError) {
+      console.error('failed to revoke personal access token', revokeError);
+      setError('Unable to revoke token. Refresh to try again.');
+    }
+  }, []);
+
+  const closeModal = useCallback(() => {
+    if (!creating) {
+      setModalOpen(false);
+      resetForm();
+    }
+  }, [creating, resetForm]);
+
+  const dismissSecret = useCallback(() => {
+    setSecret(null);
+  }, []);
+
+  const sortedTokens = useMemo(() => {
+    return [...tokens].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  }, [tokens]);
+
+  return (
+    <section className="rounded-3xl border border-slate-700 bg-slate-900/60 p-6 shadow-lg">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col">
+          <h2 className="text-xl font-semibold text-slate-100">Personal access tokens</h2>
+          <p className="text-sm text-slate-400">
+            Generate secrets for CLI or API access. Tokens inherit your current roles and can be revoked at any time.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setModalOpen(true);
+            setCreationError(null);
+          }}
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 sm:mt-0"
+        >
+          Create token
+        </button>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-4">
+        {secret ? <TokenSecretBanner secret={secret} onDismiss={dismissSecret} /> : null}
+        {error ? (
+          <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>
+        ) : null}
+        {loading ? (
+          <div className="rounded-2xl border border-slate-700/70 bg-slate-900/40 p-6 text-center text-sm text-slate-400">Loading tokens…</div>
+        ) : sortedTokens.length === 0 ? (
+          <div className="rounded-2xl border border-slate-700/70 bg-slate-900/40 p-6 text-center text-sm text-slate-400">
+            No tokens yet. Create one to automate workflows securely.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {sortedTokens.map((token) => (
+              <div
+                key={token.id}
+                className="flex flex-col gap-3 rounded-2xl border border-slate-700/70 bg-slate-900/40 p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex flex-1 flex-col gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold text-slate-100">{token.name}</span>
+                    {token.revoked ? (
+                      <span className="rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-red-200">
+                        Revoked
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="grid gap-1 text-xs text-slate-400 sm:grid-cols-2 sm:text-sm">
+                    <span>
+                      Created <strong className="font-medium text-slate-200">{formatDate(token.created_at)}</strong>
+                    </span>
+                    <span>
+                      Last used{' '}
+                      <strong className="font-medium text-slate-200">{formatDate(token.last_used_at)}</strong>
+                    </span>
+                    <span>
+                      Expires{' '}
+                      <strong className="font-medium text-slate-200">{token.expires_at ? formatDate(token.expires_at) : 'Never'}</strong>
+                    </span>
+                    <ScopesList scopes={token.scopes} />
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleRevoke(token.id)}
+                    disabled={token.revoked}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-600/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-red-400 hover:text-red-200 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {token.revoked ? 'Revoked' : 'Revoke'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {modalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
+          <div className="w-full max-w-lg rounded-3xl border border-slate-700 bg-slate-900 p-6 shadow-2xl">
+            <form className="flex flex-col gap-4" onSubmit={handleCreate}>
+              <div className="flex flex-col gap-2">
+                <h3 className="text-lg font-semibold text-slate-100">Create personal access token</h3>
+                <p className="text-sm text-slate-400">
+                  Tokens are scoped to your account. Store the generated secret securely — it cannot be recovered later.
+                </p>
+              </div>
+
+              <label className="flex flex-col gap-2 text-sm text-slate-200">
+                <span className="font-semibold">Name</span>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  maxLength={200}
+                  required
+                  placeholder="CLI on Hayden’s MacBook Air"
+                  className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-400/40"
+                />
+              </label>
+
+              <fieldset className="flex flex-col gap-2">
+                <legend className="text-sm font-semibold text-slate-200">Scopes</legend>
+                <label className="flex items-center gap-2 text-sm text-slate-200">
+                  <input
+                    type="checkbox"
+                    checked={scopeRead}
+                    onChange={(event) => setScopeRead(event.target.checked)}
+                    className="h-4 w-4 rounded border-slate-600 bg-slate-900 text-sky-400 focus:ring-sky-400"
+                  />
+                  <span>Read</span>
+                </label>
+                <label className="flex items-center gap-2 text-sm text-slate-200">
+                  <input
+                    type="checkbox"
+                    checked={scopeWrite}
+                    onChange={(event) => setScopeWrite(event.target.checked)}
+                    className="h-4 w-4 rounded border-slate-600 bg-slate-900 text-sky-400 focus:ring-sky-400"
+                  />
+                  <span>Write</span>
+                </label>
+                <p className="text-xs text-slate-500">Leave both selected for full access.</p>
+              </fieldset>
+
+              <label className="flex flex-col gap-2 text-sm text-slate-200">
+                <span className="font-semibold">Expiry (optional)</span>
+                <input
+                  type="date"
+                  value={expiry}
+                  onChange={(event) => setExpiry(event.target.value)}
+                  className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-400/40"
+                />
+                <span className="text-xs text-slate-500">Token will expire at 00:00 UTC on the selected date.</span>
+              </label>
+
+              {creationError ? (
+                <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">{creationError}</div>
+              ) : null}
+
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-600/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-slate-100"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={creating}
+                  className="inline-flex items-center justify-center rounded-full bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  {creating ? 'Creating…' : 'Create token'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/console/lib/analytics.ts
+++ b/apps/console/lib/analytics.ts
@@ -15,7 +15,7 @@ type NavItem = {
   href: string;
   label: string;
   permission?: PermissionKey;
-  group?: 'Operations' | 'Security' | 'Admin';
+  group?: 'Operations' | 'Security' | 'Admin' | 'Account';
 };
 
 const NAV_ITEMS: NavItem[] = [
@@ -23,10 +23,11 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/alerts', label: 'Alerts', group: 'Operations' },
   { href: '/investigations', label: 'Investigations', permission: 'investigations.view', group: 'Operations' },
   { href: '/releases', label: 'Releases', permission: 'releases.simulate', group: 'Operations' },
-  { href: '/audit', label: 'Audit trail', permission: 'audit.read', group: 'Security' }
+  { href: '/audit', label: 'Audit trail', permission: 'audit.read', group: 'Security' },
+  { href: '/profile', label: 'Profile', group: 'Account' }
 ];
 
-const NAV_GROUP_ORDER: Array<NonNullable<NavItem['group']>> = ['Operations', 'Security', 'Admin'];
+const NAV_GROUP_ORDER: Array<NonNullable<NavItem['group']>> = ['Operations', 'Security', 'Account', 'Admin'];
 
 class AnalyticsClient {
   private readonly queue: Array<{ event: AnalyticsEventKey; payload: AnalyticsPayload }> = [];

--- a/apps/console/lib/self.ts
+++ b/apps/console/lib/self.ts
@@ -1,0 +1,53 @@
+import { getRequesterEmail, getUserRolesByEmail } from './auth';
+import { createSupabaseServiceRoleClient } from './supabase';
+
+export type SelfProfile = {
+  user_id: string;
+  email: string;
+  display_name: string;
+  roles: string[];
+};
+
+export async function getSelf(request: Request): Promise<SelfProfile | null> {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return null;
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  type StaffRow = {
+    user_id: string;
+    email: string;
+    display_name: string | null;
+  } | null;
+
+  const { data, error } = await (supabase.from('staff_users') as any)
+    .select('user_id, email, display_name')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (error) {
+    console.error('failed to resolve self profile', error);
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRolesByEmail(email, supabase);
+  } catch (roleError) {
+    console.error('failed to resolve self roles', roleError);
+    throw roleError;
+  }
+
+  return {
+    user_id: data.user_id,
+    email: data.email.toLowerCase(),
+    display_name: data.display_name ?? data.email,
+    roles
+  };
+}

--- a/apps/console/server/pat.ts
+++ b/apps/console/server/pat.ts
@@ -1,0 +1,126 @@
+import { createHash, randomBytes } from 'crypto';
+import { createSupabaseServiceRoleClient } from '../lib/supabase';
+
+const TOKEN_PREFIX = 'torv_pat_';
+const TOKEN_BYTE_LENGTH = 32;
+
+export type PersonalAccessTokenRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+  revoked: boolean;
+};
+
+function normaliseScopes(scopes: string[] | null | undefined): string[] {
+  if (!scopes || scopes.length === 0) {
+    return ['read', 'write'];
+  }
+
+  const allowedScopes = new Set(['read', 'write']);
+  const filtered = scopes
+    .map((scope) => scope.trim())
+    .filter((scope) => allowedScopes.has(scope));
+
+  return filtered.length > 0 ? Array.from(new Set(filtered)) : ['read', 'write'];
+}
+
+function hashToken(token: string): string {
+  const digest = createHash('sha256').update(token).digest('hex');
+  return `\\x${digest}`;
+}
+
+export async function createPat(
+  userId: string,
+  name: string,
+  scopes?: string[],
+  expiresAt?: Date | null
+): Promise<{ token: string; row: PersonalAccessTokenRow }> {
+  const supabase = createSupabaseServiceRoleClient();
+  const tokenBytes = randomBytes(TOKEN_BYTE_LENGTH);
+  const tokenSecret = `${TOKEN_PREFIX}${tokenBytes.toString('base64url')}`;
+  const tokenHash = hashToken(tokenSecret);
+  const payload: Record<string, unknown> = {
+    user_id: userId,
+    name,
+    token_hash: tokenHash,
+    scopes: normaliseScopes(scopes)
+  };
+
+  if (expiresAt) {
+    payload.expires_at = expiresAt.toISOString();
+  }
+
+  const { data, error } = await (supabase.from('personal_access_tokens') as any)
+    .insert(payload)
+    .select('id, user_id, name, scopes, created_at, last_used_at, expires_at, revoked')
+    .single();
+
+  if (error) {
+    console.error('failed to create personal access token', error);
+    throw error;
+  }
+
+  const row = data as PersonalAccessTokenRow;
+
+  return { token: tokenSecret, row };
+}
+
+export async function listPats(userId: string): Promise<PersonalAccessTokenRow[]> {
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await (supabase.from('personal_access_tokens') as any)
+    .select('id, user_id, name, scopes, created_at, last_used_at, expires_at, revoked')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('failed to list personal access tokens', error);
+    throw error;
+  }
+
+  return ((data as PersonalAccessTokenRow[] | null) ?? []).map((row) => ({
+    ...row,
+    scopes: normaliseScopes(row.scopes)
+  }));
+}
+
+export async function revokePat(id: string, userId: string): Promise<PersonalAccessTokenRow | null> {
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await (supabase.from('personal_access_tokens') as any)
+    .update({ revoked: true })
+    .eq('id', id)
+    .eq('user_id', userId)
+    .eq('revoked', false)
+    .select('id, user_id, name, scopes, created_at, last_used_at, expires_at, revoked')
+    .maybeSingle();
+
+  if (error) {
+    console.error('failed to revoke personal access token', error);
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const row = data as PersonalAccessTokenRow;
+  return {
+    ...row,
+    scopes: normaliseScopes(row.scopes)
+  };
+}
+
+export async function touchPatUsage(id: string): Promise<void> {
+  const supabase = createSupabaseServiceRoleClient();
+  const { error } = await (supabase.from('personal_access_tokens') as any)
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) {
+    console.error('failed to update personal access token usage', error);
+    throw error;
+  }
+}

--- a/supabase/migrations/20250925_personal_access_tokens.sql
+++ b/supabase/migrations/20250925_personal_access_tokens.sql
@@ -1,0 +1,21 @@
+create table if not exists public.personal_access_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.staff_users(user_id) on delete cascade,
+  name text not null,
+  token_hash bytea not null,
+  scopes text[] not null default '{read,write}',
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz null,
+  expires_at timestamptz null,
+  revoked boolean not null default false,
+  constraint personal_access_tokens_user_id_name_key unique (user_id, name)
+);
+
+create index if not exists personal_access_tokens_user_id_idx
+  on public.personal_access_tokens (user_id);
+
+create index if not exists personal_access_tokens_revoked_expires_at_idx
+  on public.personal_access_tokens (revoked, expires_at);
+
+create index if not exists personal_access_tokens_last_used_at_idx
+  on public.personal_access_tokens (last_used_at);


### PR DESCRIPTION
## Summary
- add a personal_access_tokens table migration with hashed secrets and supporting indexes
- expose server helpers and API routes to resolve the signed-in staff profile and manage personal access tokens
- refresh the profile page with a PAT management panel and surface a Profile link in navigation

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68cffaf32624832d96ae3119813349b9