### PR TITLE
Add admin role assignment management

### DIFF
--- a/apps/console/app/admin/roles/page.tsx
+++ b/apps/console/app/admin/roles/page.tsx
@@ -1,0 +1,100 @@
+import { cookies, headers } from 'next/headers';
+import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { RoleManager, type RoleMemberRecord } from '../../../components/admin/RoleManager';
+import { getStaffUser } from '../../../lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+type RoleDefinition = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+type RolesApiResponse = {
+  roles: RoleDefinition[];
+  members: RoleMemberRecord[];
+};
+
+type FetchRolesResult =
+  | { status: 401 | 403; data: null }
+  | { status: 200; data: RolesApiResponse };
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+async function fetchRoles(baseUrl: string, emailHeader: string | null): Promise<FetchRolesResult> {
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const headersMap = new Headers();
+  if (cookieHeader) {
+    headersMap.set('cookie', cookieHeader);
+  }
+  if (emailHeader) {
+    headersMap.set('cf-access-authenticated-user-email', emailHeader);
+  }
+
+  const response = await fetch(`${baseUrl}/api/admin/roles`, {
+    cache: 'no-store',
+    headers: headersMap
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    return { status: response.status as 401 | 403, data: null };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load roles (${response.status})`);
+  }
+
+  const payload = (await response.json()) as RolesApiResponse;
+  return { status: 200, data: payload };
+}
+
+export default async function AdminRolesPage() {
+  const staffUser = await getStaffUser();
+
+  if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
+    return <AccessDeniedNotice />;
+  }
+
+  const headerBag = headers();
+  const host = headerBag.get('x-forwarded-host') ?? headerBag.get('host');
+  const protoHeader = headerBag.get('x-forwarded-proto');
+
+  let baseUrl: string;
+  if (host) {
+    const normalisedHost = host.toLowerCase();
+    const defaultProto = normalisedHost.includes('localhost') || normalisedHost.includes('127.0.0.1') ? 'http' : 'https';
+    const protocol = protoHeader ?? defaultProto;
+    baseUrl = `${protocol}://${host}`;
+  } else {
+    baseUrl = process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
+  }
+
+  const headerEmail =
+    headerBag.get('cf-access-authenticated-user-email')
+    ?? headerBag.get('Cf-Access-Authenticated-User-Email')
+    ?? staffUser.email;
+
+  const { status, data } = await fetchRoles(baseUrl, headerEmail);
+
+  if (status === 401 || status === 403) {
+    return <AccessDeniedNotice />;
+  }
+
+  if (!data) {
+    throw new Error('Roles payload missing');
+  }
+
+  return (
+    <div className="page">
+      <RoleManager roles={data.roles} members={data.members} />
+    </div>
+  );
+}

--- a/apps/console/app/api/admin/roles/assign/route.ts
+++ b/apps/console/app/api/admin/roles/assign/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+import { getRequesterEmail, getUserRolesByEmail } from '../../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { logAudit } from '../../../../../server/audit';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+type StaffRoleRow = {
+  id: string;
+  name: string;
+};
+
+export async function POST(request: Request) {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let requesterRoles: string[];
+  try {
+    requesterRoles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('Failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(requesterRoles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const userId = typeof (payload as any)?.user_id === 'string' ? (payload as any).user_id.trim() : '';
+  const roleName = typeof (payload as any)?.role_name === 'string' ? (payload as any).role_name.trim() : '';
+
+  if (!userId || !roleName) {
+    return NextResponse.json({ error: 'user_id and role_name are required' }, { status: 400 });
+  }
+
+  const normalisedRole = roleName.toLowerCase();
+
+  const { data: roleRow, error: roleError } = await (supabase.from('staff_roles') as any)
+    .select('id, name')
+    .eq('name', normalisedRole)
+    .maybeSingle();
+
+  if (roleError && roleError.code !== 'PGRST116') {
+    console.error('Failed to resolve role for assignment', roleError);
+    return new Response('failed to resolve role', { status: 500 });
+  }
+
+  if (!roleRow) {
+    return NextResponse.json({ error: `Role ${roleName} not found` }, { status: 404 });
+  }
+
+  const { data: userRow, error: userError } = await (supabase.from('staff_users') as any)
+    .select('user_id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (userError && userError.code !== 'PGRST116') {
+    console.error('Failed to resolve staff user for assignment', userError);
+    return new Response('failed to resolve user', { status: 500 });
+  }
+
+  if (!userRow) {
+    return NextResponse.json({ error: `Staff user ${userId} not found` }, { status: 404 });
+  }
+
+  const roleData = roleRow as StaffRoleRow;
+  const roleId = roleData.id;
+  const canonicalRoleName = (roleData.name || normalisedRole).trim();
+
+  const { error: upsertError } = await (supabase.from('staff_role_members') as any)
+    .upsert({ user_id: userId, role_id: roleId }, { onConflict: 'user_id,role_id' });
+
+  if (upsertError) {
+    console.error('Failed to assign role', upsertError);
+    return new Response('failed to assign role', { status: 500 });
+  }
+
+  try {
+    await logAudit(
+      {
+        action: 'role_assign',
+        targetType: 'user',
+        targetId: userId,
+        meta: { role_name: canonicalRoleName }
+      },
+      request
+    );
+  } catch (error) {
+    console.error('Failed to log audit entry for role assignment', error);
+  }
+
+  return NextResponse.json({ success: true, role_name: canonicalRoleName });
+}

--- a/apps/console/app/api/admin/roles/route.ts
+++ b/apps/console/app/api/admin/roles/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { getRequesterEmail, getUserRolesByEmail } from '../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+type RoleRow = {
+  id: string;
+  name: string | null;
+  description: string | null;
+};
+
+type MemberRow = {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  staff_role_members?: Array<
+    | {
+        staff_roles?: {
+          name: string | null;
+        } | null;
+      }
+    | null
+  > | null;
+};
+
+export async function GET(request: Request) {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let requesterRoles: string[];
+  try {
+    requesterRoles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('Failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(requesterRoles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  const { data: roleRows, error: roleError } = await (supabase.from('staff_roles') as any)
+    .select('id, name, description')
+    .order('name', { ascending: true });
+
+  if (roleError) {
+    console.error('Failed to load staff roles', roleError);
+    return new Response('failed to load roles', { status: 500 });
+  }
+
+  const { data: memberRows, error: memberError } = await (supabase.from('staff_users') as any)
+    .select(
+      `user_id, email, display_name,
+        staff_role_members:staff_role_members (
+          staff_roles:staff_roles ( name )
+        )`
+    )
+    .order('email', { ascending: true });
+
+  if (memberError) {
+    console.error('Failed to load staff members', memberError);
+    return new Response('failed to load members', { status: 500 });
+  }
+
+  const roles = ((roleRows as RoleRow[] | null) ?? []).map((row) => ({
+    id: row.id,
+    name: row.name?.trim() ?? '',
+    description: row.description?.trim() ?? ''
+  }));
+
+  roles.sort((a, b) => a.name.localeCompare(b.name));
+
+  const members = ((memberRows as MemberRow[] | null) ?? []).map((row) => {
+    const roleNames = (row.staff_role_members ?? [])
+      .map((membership) => membership?.staff_roles?.name?.trim() ?? null)
+      .filter((role): role is string => Boolean(role));
+
+    roleNames.sort((a, b) => a.localeCompare(b));
+
+    return {
+      user_id: row.user_id,
+      email: row.email.toLowerCase(),
+      display_name: row.display_name,
+      roles: Array.from(new Set(roleNames))
+    };
+  });
+
+  return NextResponse.json({ roles, members });
+}

--- a/apps/console/app/api/admin/roles/unassign/route.ts
+++ b/apps/console/app/api/admin/roles/unassign/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import { getRequesterEmail, getUserRolesByEmail } from '../../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { logAudit } from '../../../../../server/audit';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+type StaffRoleRow = {
+  id: string;
+  name: string;
+};
+
+export async function POST(request: Request) {
+  const email = getRequesterEmail(request);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let requesterRoles: string[];
+  try {
+    requesterRoles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('Failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(requesterRoles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const userId = typeof (payload as any)?.user_id === 'string' ? (payload as any).user_id.trim() : '';
+  const roleName = typeof (payload as any)?.role_name === 'string' ? (payload as any).role_name.trim() : '';
+
+  if (!userId || !roleName) {
+    return NextResponse.json({ error: 'user_id and role_name are required' }, { status: 400 });
+  }
+
+  const normalisedRole = roleName.toLowerCase();
+
+  const { data: roleRow, error: roleError } = await (supabase.from('staff_roles') as any)
+    .select('id, name')
+    .eq('name', normalisedRole)
+    .maybeSingle();
+
+  if (roleError && roleError.code !== 'PGRST116') {
+    console.error('Failed to resolve role for unassignment', roleError);
+    return new Response('failed to resolve role', { status: 500 });
+  }
+
+  if (!roleRow) {
+    return NextResponse.json({ error: `Role ${roleName} not found` }, { status: 404 });
+  }
+
+  const roleData = roleRow as StaffRoleRow;
+  const roleId = roleData.id;
+  const canonicalRoleName = (roleData.name || normalisedRole).trim();
+
+  const membershipQuery = (supabase.from('staff_role_members') as any)
+    .select('user_id')
+    .eq('user_id', userId)
+    .eq('role_id', roleId)
+    .maybeSingle();
+
+  const { data: membershipRow, error: membershipError } = await membershipQuery;
+
+  if (membershipError && membershipError.code !== 'PGRST116') {
+    console.error('Failed to check existing membership', membershipError);
+    return new Response('failed to check membership', { status: 500 });
+  }
+
+  const isMember = Boolean(membershipRow);
+
+  if (!isMember) {
+    return NextResponse.json({ success: true, role_name: canonicalRoleName, removed: false });
+  }
+
+  if (canonicalRoleName.toLowerCase() === 'security_admin') {
+    const { data: adminRows, error: adminError } = await (supabase.from('staff_role_members') as any)
+      .select('user_id')
+      .eq('role_id', roleId);
+
+    if (adminError) {
+      console.error('Failed to evaluate security_admin membership', adminError);
+      return new Response('failed to check security_admin membership', { status: 500 });
+    }
+
+    const adminCount = (adminRows ?? []).length;
+    if (adminCount <= 1) {
+      return NextResponse.json(
+        {
+          error: 'Cannot remove the last security_admin. Assign another administrator before removing this role.'
+        },
+        { status: 409 }
+      );
+    }
+  }
+
+  const { error: deleteError } = await (supabase.from('staff_role_members') as any)
+    .delete()
+    .eq('user_id', userId)
+    .eq('role_id', roleId);
+
+  if (deleteError) {
+    console.error('Failed to unassign role', deleteError);
+    return new Response('failed to unassign role', { status: 500 });
+  }
+
+  try {
+    await logAudit(
+      {
+        action: 'role_unassign',
+        targetType: 'user',
+        targetId: userId,
+        meta: { role_name: canonicalRoleName }
+      },
+      request
+    );
+  } catch (error) {
+    console.error('Failed to log audit entry for role removal', error);
+  }
+
+  return NextResponse.json({ success: true, role_name: canonicalRoleName, removed: true });
+}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -69,7 +69,8 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   if (hasSecurityAdminRole) {
     const adminGroup = navGroups.find((group) => group.group === 'Admin');
     const adminItems = [
-      { href: '/admin/people', label: 'Admin' },
+      { href: '/admin/people', label: 'People' },
+      { href: '/admin/roles', label: 'Roles' },
       { href: '/staff', label: 'Staff' }
     ];
 

--- a/apps/console/components/admin/RoleManager.tsx
+++ b/apps/console/components/admin/RoleManager.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import clsx from 'clsx';
+
+type RoleDefinition = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type RoleMemberRecord = {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  roles: string[];
+};
+
+export type RoleManagerProps = {
+  roles: RoleDefinition[];
+  members: RoleMemberRecord[];
+};
+
+type StatusMessage = {
+  type: 'success' | 'error';
+  message: string;
+};
+
+function normaliseRoleName(role: string): string {
+  return role.trim().toLowerCase();
+}
+
+function sortRoleNames(roles: string[]): string[] {
+  const unique = Array.from(new Set(roles.map((role) => role.trim()).filter(Boolean)));
+  unique.sort((a, b) => a.localeCompare(b));
+  return unique;
+}
+
+function filterMembers(members: RoleMemberRecord[], query: string) {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return members;
+  }
+
+  return members.filter((member) => {
+    const displayName = member.display_name ?? '';
+    return (
+      member.email.toLowerCase().includes(trimmed)
+      || displayName.toLowerCase().includes(trimmed)
+    );
+  });
+}
+
+function describeMember(member: RoleMemberRecord | undefined): string {
+  if (!member) {
+    return 'the selected staff member';
+  }
+
+  if (member.display_name) {
+    return `${member.display_name} (${member.email})`;
+  }
+
+  return member.email;
+}
+
+function RoleChip({
+  role,
+  onRemove,
+  disabled
+}: {
+  role: string;
+  onRemove: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-slate-600/60 bg-slate-800/60 px-2 py-0.5 text-xs font-medium text-slate-200">
+      <span>{role}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        className={clsx(
+          'rounded-full p-0.5 text-slate-300 transition hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60 focus:ring-offset-2 focus:ring-offset-slate-900',
+          disabled && 'cursor-not-allowed opacity-40 hover:text-slate-300'
+        )}
+        aria-label={`Remove ${role}`}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+export function RoleManager({ roles, members }: RoleManagerProps) {
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [selectedUser, setSelectedUser] = useState<string>(() => members[0]?.user_id ?? '');
+  const [selectedRole, setSelectedRole] = useState<string>(() => roles[0]?.name ?? '');
+  const [records, setRecords] = useState<RoleMemberRecord[]>(members);
+
+  useEffect(() => {
+    setRecords(members);
+    setSelectedUser((current) => {
+      if (current && members.some((member) => member.user_id === current)) {
+        return current;
+      }
+      return members[0]?.user_id ?? '';
+    });
+  }, [members]);
+
+  useEffect(() => {
+    setSelectedRole((current) => {
+      if (current && roles.some((role) => role.name === current)) {
+        return current;
+      }
+      return roles[0]?.name ?? '';
+    });
+  }, [roles]);
+
+  const filteredMembers = useMemo(() => filterMembers(records, query), [records, query]);
+
+  function updateMemberRoles(userId: string, mapper: (roles: string[]) => string[]) {
+    setRecords((prev) =>
+      prev.map((member) => {
+        if (member.user_id !== userId) {
+          return member;
+        }
+        const nextRoles = mapper(member.roles);
+        return { ...member, roles: sortRoleNames(nextRoles) };
+      })
+    );
+  }
+
+  async function assignRole(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!selectedUser || !selectedRole) {
+      setStatus({ type: 'error', message: 'Select a staff member and role to assign.' });
+      return;
+    }
+
+    const actionKey = `assign:${selectedUser}:${selectedRole}`;
+    setPendingAction(actionKey);
+    setStatus(null);
+
+    try {
+      const response = await fetch('/api/admin/roles/assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: selectedUser, role_name: selectedRole })
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? 'Failed to assign role.';
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      const canonicalRole = typeof (payload as any)?.role_name === 'string' ? (payload as any).role_name : selectedRole;
+
+      updateMemberRoles(selectedUser, (rolesList) => {
+        const merged = new Set([...rolesList, canonicalRole]);
+        return Array.from(merged);
+      });
+
+      const targetMember = records.find((member) => member.user_id === selectedUser);
+      setStatus({ type: 'success', message: `Assigned ${canonicalRole} to ${describeMember(targetMember)}.` });
+    } catch (error) {
+      console.error('Failed to assign role', error);
+      setStatus({ type: 'error', message: 'Unexpected error assigning role.' });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function removeRole(userId: string, role: string) {
+    const normalised = normaliseRoleName(role);
+    if (normalised === 'security_admin') {
+      const confirmed = window.confirm(
+        'Removing the security_admin role reduces administrator coverage. Are you sure you want to continue?'
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    const actionKey = `unassign:${userId}:${role}`;
+    setPendingAction(actionKey);
+    setStatus(null);
+
+    try {
+      const response = await fetch('/api/admin/roles/unassign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, role_name: role })
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? 'Failed to remove role.';
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      const canonicalRole = typeof (payload as any)?.role_name === 'string' ? (payload as any).role_name : role;
+
+      if ((payload as any)?.removed) {
+        updateMemberRoles(userId, (rolesList) =>
+          rolesList.filter((entry) => normaliseRoleName(entry) !== normaliseRoleName(canonicalRole))
+        );
+        const targetMember = records.find((member) => member.user_id === userId);
+        setStatus({ type: 'success', message: `Removed ${canonicalRole} from ${describeMember(targetMember)}.` });
+      } else {
+        const targetMember = records.find((member) => member.user_id === userId);
+        setStatus({ type: 'success', message: `${canonicalRole} was not assigned to ${describeMember(targetMember)}.` });
+      }
+    } catch (error) {
+      console.error('Failed to remove role', error);
+      setStatus({ type: 'error', message: 'Unexpected error removing role.' });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Role assignments</h1>
+          <p className="text-sm text-slate-400">
+            Manage privileged roles for Torvus staff. Roles determine access to sensitive console features.
+          </p>
+        </div>
+        <label
+          className={clsx(
+            'flex w-full items-center gap-2 rounded-full border border-slate-700 bg-slate-950/60 px-4 py-2 text-sm text-slate-200 focus-within:border-slate-500',
+            'lg:w-auto'
+          )}
+        >
+          <span className="sr-only">Filter staff</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter by email or name"
+            className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+          />
+        </label>
+      </div>
+
+      {status ? (
+        <div
+          role="status"
+          className={clsx(
+            'rounded-2xl border px-4 py-3 text-sm',
+            status.type === 'success'
+              ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+              : 'border-rose-500/40 bg-rose-500/10 text-rose-100'
+          )}
+        >
+          {status.message}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="overflow-hidden rounded-2xl border border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm text-slate-200">
+            <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  Email
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Display name
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Roles
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/60">
+              {filteredMembers.length === 0 ? (
+                <tr>
+                  <td colSpan={3} className="px-6 py-12 text-center text-sm text-slate-400">
+                    No staff members match your filter.
+                  </td>
+                </tr>
+              ) : (
+                filteredMembers.map((member) => (
+                  <tr key={member.user_id} className="transition hover:bg-slate-800/40">
+                    <td className="px-6 py-4 text-sm font-medium text-slate-100">{member.email}</td>
+                    <td className="px-6 py-4 text-sm text-slate-300">{member.display_name ?? '—'}</td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-wrap gap-2">
+                        {member.roles.length ? (
+                          member.roles.map((role) => (
+                            <RoleChip
+                              key={`${member.user_id}-${role}`}
+                              role={role}
+                              disabled={pendingAction !== null}
+                              onRemove={() => removeRole(member.user_id, role)}
+                            />
+                          ))
+                        ) : (
+                          <span className="text-xs text-slate-500">—</span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <aside className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/60 p-6">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Assign role</h2>
+            <p className="text-xs text-slate-400">Select a staff member and assign an available role.</p>
+          </div>
+          <form className="flex flex-col gap-4" onSubmit={assignRole}>
+            <label className="flex flex-col gap-2 text-sm text-slate-200">
+              <span>Staff member</span>
+              <select
+                value={selectedUser}
+                onChange={(event) => setSelectedUser(event.target.value)}
+                className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+              >
+                {records.length === 0 ? (
+                  <option value="" disabled>
+                    No staff available
+                  </option>
+                ) : (
+                  records.map((member) => (
+                    <option key={member.user_id} value={member.user_id}>
+                      {member.display_name ? `${member.display_name} (${member.email})` : member.email}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-200">
+              <span>Role</span>
+              <select
+                value={selectedRole}
+                onChange={(event) => setSelectedRole(event.target.value)}
+                className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+              >
+                {roles.length === 0 ? (
+                  <option value="" disabled>
+                    No roles available
+                  </option>
+                ) : (
+                  roles.map((role) => (
+                    <option key={role.id} value={role.name}>
+                      {role.name}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+            <button
+              type="submit"
+              disabled={pendingAction !== null || !selectedUser || !selectedRole}
+              className={clsx(
+                'inline-flex items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/30 focus:outline-none focus:ring-2 focus:ring-emerald-500/60 focus:ring-offset-2 focus:ring-offset-slate-950',
+                pendingAction !== null && 'cursor-not-allowed opacity-50'
+              )}
+            >
+              Assign role
+            </button>
+          </form>
+        </aside>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- implement admin roles listing plus assign/unassign endpoints with audit logging and protection against removing the last security_admin
- add the /admin/roles page and RoleManager client to review staff memberships, filter members, and manage assignments with confirmation for security_admin removal
- surface the new Roles screen from the admin navigation next to People and Staff

## Testing
- pnpm --filter @torvus/console lint
- pnpm --filter @torvus/console test


------
https://chatgpt.com/codex/tasks/task_b_68cffe878e40832dbf1f0de404cfcbc0