### PR TITLE
feat: add intake webhook integrations

### DIFF
--- a/apps/console/app/admin/integrations/intake/page.tsx
+++ b/apps/console/app/admin/integrations/intake/page.tsx
@@ -1,0 +1,92 @@
+import { cookies, headers } from 'next/headers';
+import { AccessDeniedNotice } from '../../../../components/AccessDeniedNotice';
+import { IntakeIntegrationsManager, type IntakeIntegrationsManagerProps } from '../../../../components/admin/IntakeIntegrationsManager';
+import { getStaffUser } from '../../../../lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+type ApiResponse = {
+  integrations: IntakeIntegrationsManagerProps['initialIntegrations'];
+};
+
+type FetchResult =
+  | { status: 401 | 403; data: null }
+  | { status: 200; data: ApiResponse };
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+async function fetchIntakeData(baseUrl: string, emailHeader: string | null): Promise<FetchResult> {
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const headersMap = new Headers();
+  if (cookieHeader) {
+    headersMap.set('cookie', cookieHeader);
+  }
+  if (emailHeader) {
+    headersMap.set('cf-access-authenticated-user-email', emailHeader);
+  }
+
+  const response = await fetch(`${baseUrl}/api/admin/integrations/intake`, {
+    cache: 'no-store',
+    headers: headersMap
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    return { status: response.status as 401 | 403, data: null };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load intake integrations (${response.status})`);
+  }
+
+  const payload = (await response.json()) as ApiResponse;
+  return { status: 200, data: payload };
+}
+
+function resolveBaseUrl(): string {
+  const headerBag = headers();
+  const host = headerBag.get('x-forwarded-host') ?? headerBag.get('host');
+  const protoHeader = headerBag.get('x-forwarded-proto');
+
+  if (host) {
+    const normalisedHost = host.toLowerCase();
+    const defaultProto = normalisedHost.includes('localhost') || normalisedHost.includes('127.0.0.1') ? 'http' : 'https';
+    const protocol = protoHeader ?? defaultProto;
+    return `${protocol}://${host}`;
+  }
+
+  return process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
+}
+
+export default async function IntakeIntegrationsPage() {
+  const staffUser = await getStaffUser();
+
+  if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
+    return <AccessDeniedNotice />;
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const headerBag = headers();
+  const headerEmail =
+    headerBag.get('cf-access-authenticated-user-email')
+    ?? headerBag.get('Cf-Access-Authenticated-User-Email')
+    ?? staffUser.email;
+
+  const { status, data } = await fetchIntakeData(baseUrl, headerEmail);
+
+  if (status === 401 || status === 403 || !data) {
+    return <AccessDeniedNotice />;
+  }
+
+  return (
+    <div className="page">
+      <IntakeIntegrationsManager initialIntegrations={data.integrations} intakeBaseUrl={baseUrl} />
+    </div>
+  );
+}

--- a/apps/console/app/api/admin/integrations/intake/[id]/rotate/route.ts
+++ b/apps/console/app/api/admin/integrations/intake/[id]/rotate/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { requireSecurityAdmin } from '../../../_helpers';
+import { rotateIntegrationSecret, countEventsByIntegration } from '../../../../../../../server/intake';
+import { normaliseSecret, serialiseIntegration } from '../../_helpers';
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const resolution = await requireSecurityAdmin(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  const id = params.id;
+  if (!id) {
+    return new Response('invalid id', { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const secret = normaliseSecret((body as any)?.secret);
+  if (!secret) {
+    return new Response('invalid secret', { status: 400 });
+  }
+
+  try {
+    const row = await rotateIntegrationSecret(id, secret, request);
+    if (!row) {
+      return new Response('not found', { status: 404 });
+    }
+    const counts = await countEventsByIntegration();
+    return NextResponse.json(serialiseIntegration(row, counts[row.id] ?? 0));
+  } catch (error) {
+    console.error('[admin][intake] failed to rotate secret', error);
+    return new Response('failed to rotate secret', { status: 500 });
+  }
+}

--- a/apps/console/app/api/admin/integrations/intake/[id]/route.ts
+++ b/apps/console/app/api/admin/integrations/intake/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { requireSecurityAdmin } from '../../_helpers';
+import { setIntegrationEnabled, countEventsByIntegration } from '../../../../../../server/intake';
+import { serialiseIntegration } from '../_helpers';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const resolution = await requireSecurityAdmin(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  const id = params.id;
+  if (!id || typeof id !== 'string') {
+    return new Response('invalid id', { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const enabledValue = (body as any)?.enabled;
+  if (typeof enabledValue !== 'boolean') {
+    return new Response('invalid enabled flag', { status: 400 });
+  }
+
+  try {
+    const row = await setIntegrationEnabled(id, enabledValue);
+    if (!row) {
+      return new Response('not found', { status: 404 });
+    }
+    const counts = await countEventsByIntegration();
+    return NextResponse.json(serialiseIntegration(row, counts[row.id] ?? 0));
+  } catch (error) {
+    console.error('[admin][intake] failed to toggle integration', error);
+    return new Response('failed to update integration', { status: 500 });
+  }
+}

--- a/apps/console/app/api/admin/integrations/intake/_helpers.ts
+++ b/apps/console/app/api/admin/integrations/intake/_helpers.ts
@@ -1,0 +1,48 @@
+import type { IntakeIntegrationKind, IntakeIntegrationRow } from '../../../../../server/intake';
+
+export const ALLOWED_INTAKE_KINDS: IntakeIntegrationKind[] = ['generic', 'statuspage', 'sentry', 'posthog'];
+
+export function normaliseKind(value: unknown): IntakeIntegrationKind | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const lower = value.trim().toLowerCase();
+  return ALLOWED_INTAKE_KINDS.includes(lower as IntakeIntegrationKind)
+    ? (lower as IntakeIntegrationKind)
+    : null;
+}
+
+export function normaliseName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 120) : null;
+}
+
+export function normaliseSecret(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length >= 8 ? trimmed : null;
+}
+
+export function maskSecret(secretHash: string): string {
+  const hex = secretHash.startsWith('\\x') ? secretHash.slice(2) : secretHash;
+  const tail = hex.slice(-6);
+  return `••••${tail}`;
+}
+
+export function serialiseIntegration(row: IntakeIntegrationRow, count: number) {
+  return {
+    id: row.id,
+    kind: row.kind,
+    name: row.name,
+    enabled: Boolean(row.enabled),
+    createdAt: row.created_at,
+    lastSeenAt: row.last_seen_at,
+    maskedSecret: maskSecret(row.secret_hash),
+    eventCount: count
+  };
+}

--- a/apps/console/app/api/admin/integrations/intake/route.ts
+++ b/apps/console/app/api/admin/integrations/intake/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { requireSecurityAdmin } from '../_helpers';
+import { listIntegrations, countEventsByIntegration, upsertIntegration, getIntegration } from '../../../../../server/intake';
+import {
+  ALLOWED_INTAKE_KINDS,
+  normaliseKind,
+  normaliseName,
+  normaliseSecret,
+  serialiseIntegration
+} from './_helpers';
+
+export async function GET(request: Request) {
+  const resolution = await requireSecurityAdmin(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  try {
+    const [integrations, counts] = await Promise.all([listIntegrations(), countEventsByIntegration()]);
+    const payload = integrations.map((row) => serialiseIntegration(row, counts[row.id] ?? 0));
+    return NextResponse.json({ integrations: payload });
+  } catch (error) {
+    console.error('[admin][intake] failed to list integrations', error);
+    return new Response('failed to list integrations', { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const resolution = await requireSecurityAdmin(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const kind = normaliseKind((body as any)?.kind);
+  if (!kind) {
+    return new Response('invalid kind', { status: 400 });
+  }
+
+  const name = normaliseName((body as any)?.name);
+  if (!name) {
+    return new Response('invalid name', { status: 400 });
+  }
+
+  const secret = normaliseSecret((body as any)?.secret);
+  if (!secret) {
+    return new Response('invalid secret', { status: 400 });
+  }
+
+  try {
+    if (!ALLOWED_INTAKE_KINDS.includes(kind)) {
+      return new Response('invalid kind', { status: 400 });
+    }
+
+    const existing = await getIntegration(kind, name);
+    if (existing) {
+      return new Response('integration already exists', { status: 409 });
+    }
+
+    const row = await upsertIntegration(kind, name, secret, request);
+    return NextResponse.json(serialiseIntegration(row, 0), { status: 201 });
+  } catch (error) {
+    console.error('[admin][intake] failed to create integration', error);
+    return new Response('failed to create integration', { status: 500 });
+  }
+}

--- a/apps/console/app/api/intake/_shared.ts
+++ b/apps/console/app/api/intake/_shared.ts
@@ -1,0 +1,85 @@
+import { createHash } from 'crypto';
+import { NextResponse } from 'next/server';
+import {
+  getIntegration,
+  recordInbound,
+  routeToInvestigation,
+  verifySignature,
+  extractVendorId,
+  type IntakeIntegrationKind
+} from '../../../server/intake';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function deriveExtId(
+  kind: IntakeIntegrationKind,
+  payload: Record<string, unknown>,
+  rawBody: string
+): string {
+  const vendorId = extractVendorId(kind, payload);
+  if (vendorId) {
+    return vendorId;
+  }
+  return createHash('sha256').update(rawBody, 'utf8').digest('hex');
+}
+
+export async function handleIntakeRequest(
+  kind: IntakeIntegrationKind,
+  request: Request
+): Promise<Response> {
+  const url = new URL(request.url);
+  const name = url.searchParams.get('name')?.trim();
+  if (!name) {
+    return new Response('missing integration name', { status: 400 });
+  }
+
+  let integration = null;
+  try {
+    integration = await getIntegration(kind, name);
+  } catch (error) {
+    console.error('[intake] failed to load integration', error);
+    return new Response('integration lookup failed', { status: 500 });
+  }
+
+  if (!integration || !integration.enabled) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(kind, rawBody, request.headers, integration.secret_hash)) {
+    return new Response('invalid signature', { status: 401 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+  } catch {
+    return new Response('invalid json', { status: 400 });
+  }
+
+  const extId = deriveExtId(kind, payload, rawBody);
+
+  try {
+    const result = await recordInbound(integration.id, extId, rawBody, payload);
+    if (result.duplicate) {
+      return NextResponse.json(
+        { ok: true, investigation_id: null, action: 'appended' },
+        { status: 202 }
+      );
+    }
+
+    const routed = await routeToInvestigation(kind, payload);
+    return NextResponse.json(
+      {
+        ok: true,
+        investigation_id: routed.id,
+        action: routed.action
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    console.error('[intake] failed to handle inbound payload', error);
+    return new Response('intake failure', { status: 500 });
+  }
+}

--- a/apps/console/app/api/intake/generic/route.ts
+++ b/apps/console/app/api/intake/generic/route.ts
@@ -1,0 +1,8 @@
+import { handleIntakeRequest } from '../_shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  return handleIntakeRequest('generic', request);
+}

--- a/apps/console/app/api/intake/posthog/route.ts
+++ b/apps/console/app/api/intake/posthog/route.ts
@@ -1,0 +1,8 @@
+import { handleIntakeRequest } from '../_shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  return handleIntakeRequest('posthog', request);
+}

--- a/apps/console/app/api/intake/sentry/route.ts
+++ b/apps/console/app/api/intake/sentry/route.ts
@@ -1,0 +1,8 @@
+import { handleIntakeRequest } from '../_shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  return handleIntakeRequest('sentry', request);
+}

--- a/apps/console/app/api/intake/statuspage/route.ts
+++ b/apps/console/app/api/intake/statuspage/route.ts
@@ -1,0 +1,8 @@
+import { handleIntakeRequest } from '../_shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  return handleIntakeRequest('statuspage', request);
+}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -72,6 +72,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       { href: '/admin/people', label: 'People' },
       { href: '/admin/roles', label: 'Roles' },
       { href: '/admin/integrations', label: 'Integrations' },
+      { href: '/admin/integrations/intake', label: 'Intake Webhooks' },
       { href: '/staff', label: 'Staff' }
     ];
 

--- a/apps/console/components/admin/IntakeIntegrationsManager.tsx
+++ b/apps/console/components/admin/IntakeIntegrationsManager.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import { useMemo, useState, type FormEvent } from 'react';
+import clsx from 'clsx';
+
+type IntakeIntegrationRecord = {
+  id: string;
+  kind: 'generic' | 'statuspage' | 'sentry' | 'posthog';
+  name: string;
+  enabled: boolean;
+  createdAt: string | null;
+  lastSeenAt: string | null;
+  maskedSecret: string;
+  eventCount: number;
+};
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+type PendingState =
+  | { type: 'create' }
+  | { type: 'toggle'; id: string }
+  | { type: 'rotate'; id: string }
+  | null;
+
+const HEADER_BY_KIND: Record<IntakeIntegrationRecord['kind'], string> = {
+  generic: 'X-Torvus-Signature',
+  statuspage: 'X-Statuspage-Signature',
+  posthog: 'X-Posthog-Signature',
+  sentry: 'Sentry-Hook-Signature'
+};
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
+}
+
+function buildCurlExample(
+  kind: IntakeIntegrationRecord['kind'],
+  name: string,
+  secret: string,
+  baseUrl: string
+): string {
+  const safeName = name.trim() || 'integration-name';
+  const body = '{"example":"payload"}';
+  const endpoint = `${baseUrl}/api/intake/${kind}?name=${encodeURIComponent(safeName)}`;
+  const headerName = HEADER_BY_KIND[kind];
+
+  const secretLine = `SECRET="${secret || 'your-shared-secret'}"`;
+  const bodyLine = `BODY='${body}'`;
+  const secretHashLine =
+    "SECRET_HASH=$(printf '%s' \"$SECRET\" | openssl dgst -sha256 -binary | xxd -p -c 64)";
+
+  if (kind === 'sentry') {
+    const signatureLine =
+      "TIMESTAMP=$(date +%s)\nSIGNATURE=$(printf '%s' \"$TIMESTAMP.$BODY\" | openssl dgst -sha256 -mac HMAC -macopt hexkey:$SECRET_HASH | awk '{print $2}')";
+    return [
+      secretLine,
+      bodyLine,
+      secretHashLine,
+      signatureLine,
+      `curl -X POST '${endpoint}' \\
+  -H 'Content-Type: application/json' \\
+  -H "Sentry-Hook-Timestamp: $TIMESTAMP" \\
+  -H "${headerName}: t=$TIMESTAMP,v1=$SIGNATURE" \\
+  -d "$BODY"`
+    ].join('\n');
+  }
+
+  const signatureLine =
+    "SIGNATURE=$(printf '%s' \"$BODY\" | openssl dgst -sha256 -mac HMAC -macopt hexkey:$SECRET_HASH | awk '{print $2}')";
+
+  return [
+    secretLine,
+    bodyLine,
+    secretHashLine,
+    signatureLine,
+    `curl -X POST '${endpoint}' \\
+  -H 'Content-Type: application/json' \\
+  -H '${headerName}: sha256=$SIGNATURE' \\
+  -d "$BODY"`
+  ].join('\n');
+}
+
+export type IntakeIntegrationsManagerProps = {
+  initialIntegrations: IntakeIntegrationRecord[];
+  intakeBaseUrl: string;
+};
+
+export function IntakeIntegrationsManager({
+  initialIntegrations,
+  intakeBaseUrl
+}: IntakeIntegrationsManagerProps) {
+  const [integrations, setIntegrations] = useState(initialIntegrations);
+  const [kind, setKind] = useState<IntakeIntegrationRecord['kind']>('generic');
+  const [name, setName] = useState('');
+  const [secret, setSecret] = useState('');
+  const [status, setStatus] = useState<StatusMessage>(null);
+  const [pending, setPending] = useState<PendingState>(null);
+
+  const example = useMemo(() => buildCurlExample(kind, name, secret, intakeBaseUrl), [kind, name, secret, intakeBaseUrl]);
+
+  const sortedIntegrations = useMemo(() => {
+    return [...integrations].sort((a, b) => {
+      if (a.createdAt && b.createdAt) {
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      }
+      if (a.createdAt) {
+        return -1;
+      }
+      if (b.createdAt) {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [integrations]);
+
+  async function createIntegration(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!name.trim()) {
+      setStatus({ type: 'error', message: 'Enter a name for the integration.' });
+      return;
+    }
+    if (secret.trim().length < 8) {
+      setStatus({ type: 'error', message: 'Secret must be at least 8 characters.' });
+      return;
+    }
+
+    setPending({ type: 'create' });
+    setStatus(null);
+
+    try {
+      const response = await fetch('/api/admin/integrations/intake', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind, name, secret })
+      });
+
+      const text = await response.text();
+      let payload: unknown = null;
+      try {
+        payload = text ? JSON.parse(text) : null;
+      } catch {
+        payload = text;
+      }
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? (typeof payload === 'string' ? payload : 'Failed to create integration.');
+        setStatus({ type: 'error', message: typeof message === 'string' ? message : 'Failed to create integration.' });
+        return;
+      }
+
+      setIntegrations((prev) => [payload as IntakeIntegrationRecord, ...prev]);
+      setName('');
+      setSecret('');
+      setKind('generic');
+      setStatus({ type: 'success', message: 'Integration created successfully.' });
+    } catch (error) {
+      console.error('Failed to create intake integration', error);
+      setStatus({ type: 'error', message: 'Unexpected error creating integration.' });
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function toggleIntegration(id: string, enabled: boolean) {
+    setPending({ type: 'toggle', id });
+    setStatus(null);
+
+    try {
+      const response = await fetch(`/api/admin/integrations/intake/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled })
+      });
+
+      const text = await response.text();
+      let payload: unknown = null;
+      try {
+        payload = text ? JSON.parse(text) : null;
+      } catch {
+        payload = text;
+      }
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? (typeof payload === 'string' ? payload : 'Failed to update integration.');
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      setIntegrations((prev) => prev.map((item) => (item.id === id ? (payload as IntakeIntegrationRecord) : item)));
+      setStatus({ type: 'success', message: enabled ? 'Integration enabled.' : 'Integration disabled.' });
+    } catch (error) {
+      console.error('Failed to toggle intake integration', error);
+      setStatus({ type: 'error', message: 'Unexpected error updating integration.' });
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function rotateIntegration(id: string) {
+    const newSecret = window.prompt('Enter a new shared secret (min 8 characters):');
+    if (!newSecret) {
+      return;
+    }
+    if (newSecret.trim().length < 8) {
+      setStatus({ type: 'error', message: 'Secret must be at least 8 characters.' });
+      return;
+    }
+
+    setPending({ type: 'rotate', id });
+    setStatus(null);
+
+    try {
+      const response = await fetch(`/api/admin/integrations/intake/${id}/rotate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: newSecret })
+      });
+
+      const text = await response.text();
+      let payload: unknown = null;
+      try {
+        payload = text ? JSON.parse(text) : null;
+      } catch {
+        payload = text;
+      }
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? (typeof payload === 'string' ? payload : 'Failed to rotate secret.');
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      setIntegrations((prev) => prev.map((item) => (item.id === id ? (payload as IntakeIntegrationRecord) : item)));
+      setStatus({ type: 'success', message: 'Secret rotated successfully.' });
+    } catch (error) {
+      console.error('Failed to rotate intake secret', error);
+      setStatus({ type: 'error', message: 'Unexpected error rotating secret.' });
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="card">
+      <h2>Intake Webhooks</h2>
+      <p className="muted">Register inbound integrations and generate signed webhook examples.</p>
+
+      <form className="form" onSubmit={createIntegration}>
+        <div className="field-row">
+          <label>
+            Kind
+            <select value={kind} onChange={(event) => setKind(event.target.value as IntakeIntegrationRecord['kind'])}>
+              <option value="generic">Generic</option>
+              <option value="statuspage">Statuspage</option>
+              <option value="sentry">Sentry</option>
+              <option value="posthog">PostHog</option>
+            </select>
+          </label>
+          <label>
+            Name
+            <input value={name} onChange={(event) => setName(event.target.value)} placeholder="production" required />
+          </label>
+          <label>
+            Shared secret
+            <input
+              type="password"
+              value={secret}
+              onChange={(event) => setSecret(event.target.value)}
+              placeholder="At least 8 characters"
+              required
+              minLength={8}
+            />
+          </label>
+        </div>
+        <button type="submit" className="button" disabled={pending?.type === 'create'}>
+          {pending?.type === 'create' ? 'Creating…' : 'Create integration'}
+        </button>
+      </form>
+
+      <div className="code-snippet">
+        <div className="code-snippet__header">cURL example</div>
+        <pre>
+          <code>{example}</code>
+        </pre>
+      </div>
+
+      {status && <div className={clsx('status', status.type)}>{status.message}</div>}
+
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Integration</th>
+            <th>Events</th>
+            <th>Last seen</th>
+            <th>Secret</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedIntegrations.length === 0 ? (
+            <tr>
+              <td colSpan={6} className="empty">
+                No intake integrations yet.
+              </td>
+            </tr>
+          ) : (
+            sortedIntegrations.map((integration) => {
+              const isToggling = pending?.type === 'toggle' && pending.id === integration.id;
+              const isRotating = pending?.type === 'rotate' && pending.id === integration.id;
+              return (
+                <tr key={integration.id}>
+                  <td>
+                    <div className="item-primary">{integration.name}</div>
+                    <div className="item-secondary">{integration.kind}</div>
+                  </td>
+                  <td>{integration.eventCount}</td>
+                  <td>
+                    <div className="item-primary">{formatTimestamp(integration.lastSeenAt)}</div>
+                    <div className="item-secondary">Created {formatTimestamp(integration.createdAt)}</div>
+                  </td>
+                  <td>{integration.maskedSecret}</td>
+                  <td>
+                    <span className={clsx('badge', integration.enabled ? 'badge--success' : 'badge--muted')}>
+                      {integration.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="actions">
+                      <button
+                        type="button"
+                        className="link"
+                        disabled={isRotating}
+                        onClick={() => rotateIntegration(integration.id)}
+                      >
+                        Rotate secret
+                      </button>
+                      <button
+                        type="button"
+                        className="link"
+                        disabled={isToggling}
+                        onClick={() => toggleIntegration(integration.id, !integration.enabled)}
+                      >
+                        {integration.enabled ? 'Disable' : 'Enable'}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/console/server/intake.ts
+++ b/apps/console/server/intake.ts
@@ -1,0 +1,851 @@
+import { createHash, createHmac, timingSafeEqual } from 'crypto';
+import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { logAudit, type RequestLike } from './audit';
+import { sendEvent } from './notify';
+import { INVESTIGATION_SEVERITIES, type InvestigationSeverity } from '../lib/investigations/constants';
+import { getStaffUserByEmail } from '../lib/auth';
+
+export type IntakeIntegrationKind = 'generic' | 'statuspage' | 'sentry' | 'posthog';
+
+export type IntakeIntegrationRow = {
+  id: string;
+  kind: IntakeIntegrationKind;
+  name: string;
+  secret_hash: string;
+  enabled: boolean;
+  created_at: string | null;
+  last_seen_at: string | null;
+};
+
+export type IntakeEventRow = {
+  id: string;
+  integration_id: string;
+  ext_id: string;
+  dedup_hash: string;
+  received_at: string | null;
+  payload: Record<string, unknown>;
+};
+
+type VerifyHeaders = Headers | Record<string, string | string[]> | { get(name: string): string | null };
+
+type RouteResult = { action: 'created' | 'appended'; id: string | null };
+
+type AutomationActor = { userId: string; email: string | null };
+
+type InvestigationSummary = {
+  vendorId: string | null;
+  title: string;
+  severity: InvestigationSeverity;
+  note: string;
+  link: string | null;
+  tags: string[];
+};
+
+function toHexBuffer(value: string): Buffer {
+  const trimmed = value.trim().toLowerCase();
+  const hex = trimmed.startsWith('0x') || trimmed.startsWith('\\x') ? trimmed.slice(2) : trimmed;
+  return Buffer.from(hex, 'hex');
+}
+
+function normaliseHeaders(input: VerifyHeaders): Headers {
+  if (input instanceof Headers) {
+    return input;
+  }
+
+  const headers = new Headers();
+
+  if (typeof (input as any).entries === 'function') {
+    for (const [key, value] of (input as any).entries() as Iterable<[string, string]>) {
+      headers.append(key, value);
+    }
+    return headers;
+  }
+
+  const entries = input as Record<string, string | string[]>;
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        headers.append(key, entry);
+      }
+    } else if (typeof value === 'string') {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function getHeaderCaseInsensitive(headers: Headers, name: string): string | null {
+  const direct = headers.get(name);
+  if (direct) {
+    return direct;
+  }
+  const lower = name.toLowerCase();
+  for (const [key, value] of headers.entries()) {
+    if (key.toLowerCase() === lower) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function constantTimeEquals(expectedHex: string, providedHex: string): boolean {
+  const normalise = (value: string) => {
+    const trimmed = value.trim();
+    const withoutPrefix = trimmed.startsWith('sha256=') ? trimmed.slice(7) : trimmed;
+    return withoutPrefix.toLowerCase();
+  };
+
+  const expected = normalise(expectedHex);
+  const provided = normalise(providedHex);
+  if (!/^[0-9a-f]+$/.test(expected) || !/^[0-9a-f]+$/.test(provided)) {
+    return false;
+  }
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const providedBuf = Buffer.from(provided, 'hex');
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuf, providedBuf);
+}
+
+function pickString(payload: Record<string, any>, keys: string[]): string | null {
+  for (const key of keys) {
+    const segments = key.split('.');
+    let current: any = payload;
+    let valid = true;
+    for (const segment of segments) {
+      if (current && typeof current === 'object' && segment in current) {
+        current = current[segment];
+      } else {
+        valid = false;
+        break;
+      }
+    }
+
+    if (!valid) {
+      continue;
+    }
+
+    if (typeof current === 'string' && current.trim()) {
+      return current.trim();
+    }
+  }
+  return null;
+}
+
+export function extractVendorId(kind: IntakeIntegrationKind, payload: Record<string, unknown>): string | null {
+  const record = payload as Record<string, any>;
+  const candidates = [
+    pickString(record, ['incident.id']),
+    pickString(record, ['issue.id']),
+    pickString(record, ['event.id']),
+    pickString(record, ['event.event_id']),
+    pickString(record, ['data.id']),
+    pickString(record, ['alert_id']),
+    pickString(record, ['uuid']),
+    pickString(record, ['id'])
+  ];
+
+  const value = candidates.find((candidate) => candidate && candidate.length >= 5) ?? null;
+
+  if (value) {
+    return value;
+  }
+
+  if (kind === 'posthog') {
+    const fallback = pickString(record, ['event.distinct_id', 'event.properties.distinct_id']);
+    if (fallback) {
+      return fallback;
+    }
+  }
+
+  return null;
+}
+
+function computeHmac(secret: Buffer, payload: string, seed?: string): string {
+  const hmac = createHmac('sha256', secret);
+  if (seed) {
+    hmac.update(seed);
+  }
+  hmac.update(payload);
+  return hmac.digest('hex');
+}
+
+function resolveSecret(secret: string | Buffer): Buffer {
+  if (Buffer.isBuffer(secret)) {
+    return secret;
+  }
+  const trimmed = secret.trim();
+  if (!trimmed) {
+    return Buffer.alloc(0);
+  }
+  if (/^\\x[0-9a-f]+$/i.test(trimmed) || /^0x[0-9a-f]+$/i.test(trimmed)) {
+    return toHexBuffer(trimmed);
+  }
+  if (/^[0-9a-f]+$/i.test(trimmed)) {
+    return Buffer.from(trimmed, 'hex');
+  }
+  return Buffer.from(trimmed, 'utf8');
+}
+
+function parseSignature(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith('sha256=')) {
+    return trimmed.slice(7);
+  }
+  return trimmed;
+}
+
+function verifyGeneric(headers: Headers, rawBody: string, secret: Buffer, headerName: string): boolean {
+  const headerValue = getHeaderCaseInsensitive(headers, headerName);
+  if (!headerValue) {
+    return false;
+  }
+  const parsed = parseSignature(headerValue);
+  if (!parsed) {
+    return false;
+  }
+  const expected = computeHmac(secret, rawBody);
+  return constantTimeEquals(expected, parsed);
+}
+
+function verifySentry(headers: Headers, rawBody: string, secret: Buffer): boolean {
+  const signatureHeader = getHeaderCaseInsensitive(headers, 'sentry-hook-signature');
+  const timestamp = getHeaderCaseInsensitive(headers, 'sentry-hook-timestamp');
+
+  if (!signatureHeader) {
+    return false;
+  }
+
+  let ts = timestamp?.trim() ?? null;
+  let provided: string | null = null;
+
+  const parts = signatureHeader.split(',');
+  for (const part of parts) {
+    const [key, value] = part.split('=', 2).map((segment) => segment.trim());
+    if (!key || !value) {
+      continue;
+    }
+    if (key === 't') {
+      ts = value;
+    } else if (key === 'v1' || key === 'v0') {
+      provided = value;
+    }
+  }
+
+  if (!ts || !provided) {
+    return false;
+  }
+
+  const expected = computeHmac(secret, rawBody, `${ts}.`);
+  return constantTimeEquals(expected, provided);
+}
+
+export function verifySignature(
+  kind: IntakeIntegrationKind,
+  rawBody: string,
+  headersInput: VerifyHeaders,
+  secret: string | Buffer
+): boolean {
+  const secretKey = resolveSecret(secret);
+  const headers = normaliseHeaders(headersInput);
+
+  if (secretKey.length === 0) {
+    return false;
+  }
+
+  switch (kind) {
+    case 'generic':
+      return verifyGeneric(headers, rawBody, secretKey, 'x-torvus-signature');
+    case 'statuspage':
+      return (
+        verifyGeneric(headers, rawBody, secretKey, 'x-statuspage-signature')
+        || verifyGeneric(headers, rawBody, secretKey, 'x-torvus-signature')
+      );
+    case 'posthog':
+      return (
+        verifyGeneric(headers, rawBody, secretKey, 'x-posthog-signature')
+        || verifyGeneric(headers, rawBody, secretKey, 'x-hub-signature-256')
+        || verifyGeneric(headers, rawBody, secretKey, 'x-torvus-signature')
+      );
+    case 'sentry':
+      return verifySentry(headers, rawBody, secretKey) || verifyGeneric(headers, rawBody, secretKey, 'sentry-signature');
+    default:
+      return false;
+  }
+}
+
+function hashSecret(secret: string): string {
+  const digest = createHash('sha256').update(secret, 'utf8').digest('hex');
+  return `\\x${digest}`;
+}
+
+export async function upsertIntegration(
+  kind: IntakeIntegrationKind,
+  name: string,
+  secretPlain: string,
+  requestLike?: RequestLike
+): Promise<IntakeIntegrationRow> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const normalisedName = name.trim();
+  const payload = {
+    kind,
+    name: normalisedName,
+    secret_hash: hashSecret(secretPlain),
+    enabled: true
+  };
+
+  const { data, error } = await (supabase.from('inbound_integrations') as any)
+    .upsert(payload, { onConflict: 'kind,name' })
+    .select('id, kind, name, secret_hash, enabled, created_at, last_seen_at')
+    .single();
+
+  if (error) {
+    console.error('[intake] failed to upsert integration', error);
+    throw error;
+  }
+
+  const row = data as IntakeIntegrationRow;
+  await logAudit(
+    {
+      action: 'intake.integration_created',
+      targetType: 'inbound_integration',
+      targetId: row.id,
+      resource: 'console.integrations',
+      meta: {
+        kind: row.kind,
+        name: row.name
+      }
+    },
+    requestLike
+  );
+
+  return row;
+}
+
+async function loadIntegrationByName(
+  kind: IntakeIntegrationKind,
+  name: string
+): Promise<IntakeIntegrationRow | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_integrations') as any)
+    .select('id, kind, name, secret_hash, enabled, created_at, last_seen_at')
+    .eq('kind', kind)
+    .eq('name', name.trim())
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('[intake] failed to load integration by name', error);
+    throw error;
+  }
+
+  return (data as IntakeIntegrationRow | null) ?? null;
+}
+
+async function findEventByExt(
+  integrationId: string,
+  extId: string
+): Promise<IntakeEventRow | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_events') as any)
+    .select('id, integration_id, ext_id, dedup_hash, received_at, payload')
+    .eq('integration_id', integrationId)
+    .eq('ext_id', extId)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    throw error;
+  }
+
+  return (data as IntakeEventRow | null) ?? null;
+}
+
+async function findEventByHash(
+  integrationId: string,
+  dedupHash: string
+): Promise<IntakeEventRow | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_events') as any)
+    .select('id, integration_id, ext_id, dedup_hash, received_at, payload')
+    .eq('integration_id', integrationId)
+    .eq('dedup_hash', dedupHash)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    throw error;
+  }
+
+  return (data as IntakeEventRow | null) ?? null;
+}
+
+function computeDedupHash(rawBody: string): string {
+  const digest = createHash('sha256').update(rawBody, 'utf8').digest('hex');
+  return `\\x${digest}`;
+}
+
+export async function recordInbound(
+  integrationId: string,
+  extId: string,
+  rawBody: string,
+  payload: Record<string, unknown>
+): Promise<{ duplicate: boolean; event: IntakeEventRow | null }> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const dedupHash = computeDedupHash(rawBody);
+
+  if (extId) {
+    const existing = await findEventByExt(integrationId, extId);
+    if (existing) {
+      await (supabase.from('inbound_integrations') as any)
+        .update({ last_seen_at: new Date().toISOString() })
+        .eq('id', integrationId);
+      return { duplicate: true, event: existing };
+    }
+  }
+
+  const existingByHash = await findEventByHash(integrationId, dedupHash);
+  if (existingByHash) {
+    await (supabase.from('inbound_integrations') as any)
+      .update({ last_seen_at: new Date().toISOString() })
+      .eq('id', integrationId);
+    return { duplicate: true, event: existingByHash };
+  }
+
+  const insertPayload = {
+    integration_id: integrationId,
+    ext_id: extId,
+    dedup_hash: dedupHash,
+    payload
+  };
+
+  const { data, error } = await (supabase.from('inbound_events') as any)
+    .insert(insertPayload)
+    .select('id, integration_id, ext_id, dedup_hash, received_at, payload')
+    .single();
+
+  if (error) {
+    console.error('[intake] failed to insert inbound event', error);
+    throw error;
+  }
+
+  const eventRow = data as IntakeEventRow;
+
+  await (supabase.from('inbound_integrations') as any)
+    .update({ last_seen_at: new Date().toISOString() })
+    .eq('id', integrationId);
+
+  await logAudit({
+    action: 'intake.event_received',
+    targetType: 'inbound_integration',
+    targetId: integrationId,
+    resource: 'console.integrations',
+    meta: {
+      event_id: eventRow.id,
+      ext_id: eventRow.ext_id
+    }
+  });
+
+  return { duplicate: false, event: eventRow };
+}
+
+function normaliseSeverity(value: unknown): InvestigationSeverity {
+  if (!value) {
+    return 'medium';
+  }
+
+  if (typeof value === 'number') {
+    if (value >= 4) {
+      return 'critical';
+    }
+    if (value === 3) {
+      return 'high';
+    }
+    if (value === 2) {
+      return 'medium';
+    }
+    return 'low';
+  }
+
+  if (typeof value !== 'string') {
+    return 'medium';
+  }
+
+  const normalised = value.trim().toLowerCase();
+  if (!normalised) {
+    return 'medium';
+  }
+
+  if (['critical', 'catastrophic', 'fatal', 'severe'].includes(normalised)) {
+    return 'critical';
+  }
+  if (['high', 'major', 'error', 'p1', 'urgent'].includes(normalised)) {
+    return 'high';
+  }
+  if (['medium', 'moderate', 'warning', 'minor', 'p2'].includes(normalised)) {
+    return 'medium';
+  }
+  if (['low', 'info', 'informational', 'p3', 'p4', 'none'].includes(normalised)) {
+    return 'low';
+  }
+
+  if (INVESTIGATION_SEVERITIES.includes(normalised as InvestigationSeverity)) {
+    return normalised as InvestigationSeverity;
+  }
+
+  return 'medium';
+}
+
+function deriveSummary(kind: IntakeIntegrationKind, payload: Record<string, any>): InvestigationSummary {
+  let vendorId: string | null = null;
+  let title = 'Automated intake event';
+  let link: string | null = null;
+  let severity: InvestigationSeverity = 'medium';
+  let note = 'Inbound event captured.';
+  const tags = new Set<string>(['source:intake', `source:${kind}`]);
+
+  vendorId = extractVendorId(kind, payload);
+
+  const urlCandidate = pickString(payload, [
+    'incident.shortlink',
+    'incident.url',
+    'web_url',
+    'url',
+    'permalink',
+    'html_url'
+  ]);
+  if (urlCandidate) {
+    link = urlCandidate;
+  }
+
+  const messageCandidate =
+    pickString(payload, ['incident.name', 'issue.title', 'event.title', 'message', 'title', 'description', 'summary'])
+    ?? 'New inbound alert';
+
+  title = `${kind}: ${messageCandidate}`.slice(0, 200);
+
+  const severityCandidate =
+    pickString(payload, [
+      'incident.impact',
+      'incident.severity',
+      'severity',
+      'issue.level',
+      'event.level',
+      'level',
+      'alert.severity'
+    ]);
+  severity = normaliseSeverity(severityCandidate);
+
+  const statusCandidate = pickString(payload, ['incident.status', 'issue.status']);
+
+  const noteLines = [messageCandidate];
+  if (statusCandidate) {
+    noteLines.push(`Status: ${statusCandidate}`);
+  }
+  if (link) {
+    noteLines.push(`Link: ${link}`);
+  }
+  note = noteLines.join('\n');
+
+  if (vendorId) {
+    tags.add(`vendor:${vendorId}`);
+    tags.add(`${kind}:${vendorId}`);
+  }
+
+  return { vendorId, title, severity, note, link, tags: Array.from(tags) };
+}
+
+async function resolveAutomationActor(): Promise<AutomationActor | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const envId = process.env.TORVUS_INTAKE_ACTOR_ID?.trim();
+  if (envId) {
+    const { data, error } = await (supabase.from('staff_users') as any)
+      .select('user_id, email')
+      .eq('user_id', envId)
+      .maybeSingle();
+    if (!error && data?.user_id) {
+      return { userId: data.user_id, email: data.email ?? null };
+    }
+  }
+
+  const envEmail = process.env.TORVUS_INTAKE_ACTOR_EMAIL?.trim();
+  if (envEmail) {
+    try {
+      const staff = await getStaffUserByEmail(envEmail, supabase);
+      if (staff) {
+        return { userId: staff.user_id, email: staff.email };
+      }
+    } catch (error) {
+      console.warn('[intake] failed to resolve intake actor email', error);
+    }
+  }
+
+  try {
+    const { data, error } = await (supabase.from('staff_users') as any)
+      .select('user_id, email, staff_role_members!inner(staff_roles!inner(name))')
+      .eq('staff_role_members.staff_roles.name', 'security_admin')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (!error && data?.user_id) {
+      return { userId: data.user_id, email: data.email ?? null };
+    }
+  } catch (error) {
+    console.warn('[intake] failed to load security admin actor', error);
+  }
+
+  try {
+    const { data, error } = await (supabase.from('staff_users') as any)
+      .select('user_id, email')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (!error && data?.user_id) {
+      return { userId: data.user_id, email: data.email ?? null };
+    }
+  } catch (error) {
+    console.warn('[intake] failed to load fallback actor', error);
+  }
+
+  return null;
+}
+
+async function findExistingInvestigation(tag: string): Promise<string | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  try {
+    const { data, error } = await (supabase.from('investigations') as any)
+      .select('id, status')
+      .contains('tags', [tag])
+      .in('status', ['open', 'triage', 'in_progress'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error && error.code !== 'PGRST116') {
+      console.error('[intake] failed to lookup existing investigation', error);
+      return null;
+    }
+
+    return data?.id ?? null;
+  } catch (error) {
+    console.error('[intake] unexpected error looking up investigation', error);
+    return null;
+  }
+}
+
+async function appendInvestigationNote(
+  investigationId: string,
+  actor: AutomationActor,
+  summary: InvestigationSummary,
+  kind: IntakeIntegrationKind,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { error } = await (supabase.from('investigation_events') as any)
+    .insert({
+      investigation_id: investigationId,
+      actor_user_id: actor.userId,
+      kind: 'note',
+      message: summary.note,
+      meta: {
+        source: 'intake',
+        kind,
+        vendor_id: summary.vendorId,
+        link: summary.link,
+        payload
+      }
+    });
+
+  if (error) {
+    console.error('[intake] failed to append investigation note', error);
+  }
+}
+
+async function createInvestigation(
+  actor: AutomationActor,
+  summary: InvestigationSummary,
+  kind: IntakeIntegrationKind,
+  payload: Record<string, unknown>
+): Promise<string | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data, error } = await (supabase.from('investigations') as any)
+    .insert({
+      title: summary.title,
+      severity: summary.severity,
+      summary: summary.note,
+      tags: summary.tags,
+      opened_by: actor.userId
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('[intake] failed to create investigation', error);
+    return null;
+  }
+
+  const investigationId = data?.id ?? null;
+  if (!investigationId) {
+    return null;
+  }
+
+  await appendInvestigationNote(investigationId, actor, summary, kind, payload);
+
+  await logAudit({
+    action: 'intake.investigation_created_from_intake',
+    targetType: 'investigation',
+    targetId: investigationId,
+    resource: 'console.investigations',
+    meta: {
+      source: 'intake',
+      vendor_id: summary.vendorId,
+      tags: summary.tags
+    }
+  });
+
+  try {
+    await sendEvent('investigation.created', {
+      id: investigationId,
+      title: summary.title,
+      severity: summary.severity,
+      source: 'intake',
+      vendor_id: summary.vendorId ?? undefined
+    });
+  } catch (error) {
+    console.warn('[intake] failed to dispatch investigation.created notification', error);
+  }
+
+  return investigationId;
+}
+
+export async function routeToInvestigation(
+  kind: IntakeIntegrationKind,
+  payload: Record<string, unknown>
+): Promise<RouteResult> {
+  const summary = deriveSummary(kind, payload as Record<string, any>);
+  const actor = await resolveAutomationActor();
+
+  if (!actor) {
+    console.error('[intake] unable to resolve automation actor; skipping intake routing');
+    return { action: 'appended', id: null };
+  }
+
+  if (summary.vendorId) {
+    const vendorTag = `${kind}:${summary.vendorId}`;
+    const existingId = await findExistingInvestigation(vendorTag);
+    if (existingId) {
+      await appendInvestigationNote(existingId, actor, summary, kind, payload);
+      return { action: 'appended', id: existingId };
+    }
+  }
+
+  const createdId = await createInvestigation(actor, summary, kind, payload);
+  return createdId ? { action: 'created', id: createdId } : { action: 'appended', id: null };
+}
+
+export async function getIntegration(
+  kind: IntakeIntegrationKind,
+  name: string
+): Promise<IntakeIntegrationRow | null> {
+  return loadIntegrationByName(kind, name);
+}
+
+export async function listIntegrations(): Promise<IntakeIntegrationRow[]> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_integrations') as any)
+    .select('id, kind, name, secret_hash, enabled, created_at, last_seen_at')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('[intake] failed to list inbound integrations', error);
+    return [];
+  }
+
+  return ((data as IntakeIntegrationRow[] | null) ?? []).map((row) => ({
+    ...row,
+    secret_hash: row.secret_hash
+  }));
+}
+
+export async function countEventsByIntegration(): Promise<Record<string, number>> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_events') as any)
+    .select('integration_id, count:count()', { head: false })
+    .group('integration_id');
+
+  if (error) {
+    console.error('[intake] failed to count inbound events', error);
+    return {};
+  }
+
+  const counts: Record<string, number> = {};
+  const rows = data as Array<{ integration_id: string; count: number }> | null;
+  if (rows) {
+    for (const row of rows) {
+      counts[row.integration_id] = Number(row.count) || 0;
+    }
+  }
+  return counts;
+}
+
+export async function rotateIntegrationSecret(
+  id: string,
+  secretPlain: string,
+  requestLike?: RequestLike
+): Promise<IntakeIntegrationRow | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const secretHash = hashSecret(secretPlain);
+
+  const { data, error } = await (supabase.from('inbound_integrations') as any)
+    .update({ secret_hash: secretHash })
+    .eq('id', id)
+    .select('id, kind, name, secret_hash, enabled, created_at, last_seen_at')
+    .maybeSingle();
+
+  if (error) {
+    console.error('[intake] failed to rotate integration secret', error);
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  await logAudit(
+    {
+      action: 'intake.integration_created',
+      targetType: 'inbound_integration',
+      targetId: id,
+      resource: 'console.integrations',
+      meta: { rotated: true }
+    },
+    requestLike
+  );
+
+  return data as IntakeIntegrationRow;
+}
+
+export async function setIntegrationEnabled(id: string, enabled: boolean): Promise<IntakeIntegrationRow | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('inbound_integrations') as any)
+    .update({ enabled })
+    .eq('id', id)
+    .select('id, kind, name, secret_hash, enabled, created_at, last_seen_at')
+    .maybeSingle();
+
+  if (error) {
+    console.error('[intake] failed to toggle integration', error);
+    throw error;
+  }
+
+  return (data as IntakeIntegrationRow | null) ?? null;
+}

--- a/supabase/migrations/20250926_intake_integrations.sql
+++ b/supabase/migrations/20250926_intake_integrations.sql
@@ -1,0 +1,41 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.inbound_integrations (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null check (kind in ('generic','statuspage','sentry','posthog')),
+  name text not null,
+  secret_hash bytea not null,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz null,
+  unique (kind, name)
+);
+
+create table if not exists public.inbound_events (
+  id uuid primary key default gen_random_uuid(),
+  integration_id uuid not null references public.inbound_integrations(id) on delete cascade,
+  ext_id text not null,
+  dedup_hash bytea not null,
+  received_at timestamptz not null default now(),
+  payload jsonb not null,
+  unique (integration_id, ext_id)
+);
+
+create index if not exists idx_inbound_events_integration_received_desc
+  on public.inbound_events (integration_id, received_at desc);
+
+create index if not exists idx_inbound_events_dedup_hash
+  on public.inbound_events (dedup_hash);
+
+alter table public.inbound_integrations enable row level security;
+alter table public.inbound_events enable row level security;
+
+create policy inbound_integrations_service_role on public.inbound_integrations
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy inbound_events_service_role on public.inbound_events
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- add inbound integration tables to store webhook metadata and payloads
- implement server utilities and API endpoints to verify, dedupe, and route intake webhooks
- deliver admin UI for managing intake integrations and generating signed cURL examples

## Testing
- pnpm test:console

------
https://chatgpt.com/codex/tasks/task_b_68d0197c758c832db40d5d24b3703f13