### PR TITLE
feat: implement dual control secrets management

### DIFF
--- a/apps/console/app/admin/secrets/approvals/page.tsx
+++ b/apps/console/app/admin/secrets/approvals/page.tsx
@@ -1,0 +1,25 @@
+import { AccessDeniedNotice } from '../../../../components/AccessDeniedNotice';
+import { SecretApprovals } from '../../../../components/admin/SecretApprovals';
+import { getStaffUser } from '../../../../lib/auth';
+import { loadSecretRequests } from '../../../../server/secrets';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export default async function SecretApprovalsPage() {
+  const staffUser = await getStaffUser();
+  if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
+    return <AccessDeniedNotice />;
+  }
+
+  const requests = await loadSecretRequests(100);
+
+  return (
+    <div className="page">
+      <SecretApprovals requests={requests} />
+    </div>
+  );
+}

--- a/apps/console/app/admin/secrets/page.tsx
+++ b/apps/console/app/admin/secrets/page.tsx
@@ -1,0 +1,25 @@
+import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { SecretsManager } from '../../../components/admin/SecretsManager';
+import { getStaffUser } from '../../../lib/auth';
+import { loadSecretsSummary, loadSecretRequests } from '../../../server/secrets';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export default async function SecretsAdminPage() {
+  const staffUser = await getStaffUser();
+  if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
+    return <AccessDeniedNotice />;
+  }
+
+  const [secrets, requests] = await Promise.all([loadSecretsSummary(), loadSecretRequests(50)]);
+
+  return (
+    <div className="page">
+      <SecretsManager secrets={secrets} requests={requests} />
+    </div>
+  );
+}

--- a/apps/console/app/api/admin/integrations/_helpers.ts
+++ b/apps/console/app/api/admin/integrations/_helpers.ts
@@ -34,7 +34,24 @@ export async function requireSecurityAdmin(
   return { ok: true, context: { supabase, email, roles } };
 }
 
-export function maskWebhookUrl(url: string): string {
+function maskSecretReference(reference: string): string {
+  const trimmed = reference.trim();
+  if (!trimmed) {
+    return 'secret://••••';
+  }
+  const visible = trimmed.slice(-8);
+  return `secret://…${visible}`;
+}
+
+export function maskWebhookUrl(url: string, secretKey?: string | null): string {
+  if (secretKey && secretKey.trim()) {
+    return maskSecretReference(secretKey);
+  }
+
+  if (url.startsWith('secret://')) {
+    return maskSecretReference(url.slice('secret://'.length));
+  }
+
   try {
     const parsed = new URL(url);
     const tail = parsed.pathname.replace(/\/$/, '');

--- a/apps/console/app/api/admin/integrations/route.ts
+++ b/apps/console/app/api/admin/integrations/route.ts
@@ -10,6 +10,7 @@ type WebhookRow = {
   enabled: boolean;
   description: string | null;
   created_at: string | null;
+  secret_key: string | null;
 };
 
 type PrefRow = {
@@ -24,7 +25,8 @@ function sanitiseWebhook(row: WebhookRow) {
     kind: row.kind,
     enabled: Boolean(row.enabled),
     description: row.description,
-    maskedUrl: maskWebhookUrl(row.url),
+    maskedUrl: maskWebhookUrl(row.url, row.secret_key ?? null),
+    secretKey: row.secret_key,
     createdAt: row.created_at
   };
 }
@@ -46,7 +48,7 @@ export async function GET(request: Request) {
   const { supabase } = resolution.context;
 
   const { data: webhookRows, error: webhookError } = await (supabase.from('outbound_webhooks') as any)
-    .select('id, kind, url, enabled, description, created_at')
+    .select('id, kind, url, enabled, description, created_at, secret_key')
     .order('created_at', { ascending: true });
 
   if (webhookError) {

--- a/apps/console/app/api/admin/integrations/webhooks/[id]/route.ts
+++ b/apps/console/app/api/admin/integrations/webhooks/[id]/route.ts
@@ -15,6 +15,7 @@ type WebhookRow = {
   enabled: boolean;
   description: string | null;
   created_at: string | null;
+  secret_key: string | null;
 };
 
 function sanitise(row: WebhookRow) {
@@ -23,7 +24,8 @@ function sanitise(row: WebhookRow) {
     kind: row.kind,
     enabled: Boolean(row.enabled),
     description: row.description,
-    maskedUrl: maskWebhookUrl(row.url),
+    maskedUrl: maskWebhookUrl(row.url, row.secret_key ?? null),
+    secretKey: row.secret_key,
     createdAt: row.created_at
   };
 }
@@ -66,7 +68,7 @@ export async function PATCH(
   const { data, error } = await (supabase.from('outbound_webhooks') as any)
     .update(updates)
     .eq('id', id)
-    .select('id, kind, url, enabled, description, created_at')
+    .select('id, kind, url, enabled, description, created_at, secret_key')
     .maybeSingle();
 
   if (error) {

--- a/apps/console/app/api/admin/integrations/webhooks/[id]/test/route.ts
+++ b/apps/console/app/api/admin/integrations/webhooks/[id]/test/route.ts
@@ -9,6 +9,7 @@ type WebhookRow = {
   id: string;
   kind: 'slack' | 'teams';
   url: string;
+  secret_key: string | null;
 };
 
 export async function POST(
@@ -28,7 +29,7 @@ export async function POST(
   const { supabase } = resolution.context;
 
   const { data, error } = await (supabase.from('outbound_webhooks') as any)
-    .select('id, kind, url')
+    .select('id, kind, url, secret_key')
     .eq('id', id)
     .maybeSingle();
 
@@ -43,10 +44,14 @@ export async function POST(
 
   const webhook = data as WebhookRow;
 
-  const success = await sendWebhookPreview(webhook, 'torvus.test', {
-    message: 'Test notification from Torvus Console',
-    triggered_at: new Date().toISOString()
-  });
+  const success = await sendWebhookPreview(
+    webhook,
+    'torvus.test',
+    {
+      message: 'Test notification from Torvus Console',
+      triggered_at: new Date().toISOString()
+    }
+  );
 
   if (!success) {
     return new Response('failed to deliver webhook', { status: 502 });

--- a/apps/console/app/api/admin/secrets/route.ts
+++ b/apps/console/app/api/admin/secrets/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { requireStaff } from '../../../../lib/auth';
+import { loadSecretsSummary, maskSecretTail } from '../../../../server/secrets';
+
+function assertSecurityAdmin(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const staffUser = await requireStaff();
+  if (!assertSecurityAdmin(staffUser.roles)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    const secrets = await loadSecretsSummary();
+    const payload = secrets.map((secret) => ({
+      key: secret.key,
+      env: secret.env,
+      version: secret.version,
+      lastRotatedAt: secret.lastRotatedAt,
+      lastAccessedAt: secret.lastAccessedAt,
+      requiresDualControl: secret.requiresDualControl,
+      maskedKey: maskSecretTail(secret.key, 6)
+    }));
+    return NextResponse.json({ secrets: payload });
+  } catch (error) {
+    console.error('[api][admin][secrets] failed to list secrets', error);
+    return NextResponse.json({ error: 'Failed to load secrets' }, { status: 500 });
+  }
+}

--- a/apps/console/app/api/secrets/requests/[id]/approve/route.ts
+++ b/apps/console/app/api/secrets/requests/[id]/approve/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { requireStaff } from '../../../../../../lib/auth';
+import { approve } from '../../../../../../server/secrets';
+
+function assertSecurityAdmin(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: Request,
+  context: { params: { id: string } }
+): Promise<NextResponse> {
+  const staffUser = await requireStaff();
+  if (!assertSecurityAdmin(staffUser.roles)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const requestId = context.params.id;
+  if (!requestId || requestId.length < 10) {
+    return NextResponse.json({ error: 'Invalid request id' }, { status: 400 });
+  }
+
+  try {
+    const result = await approve(requestId, staffUser.id);
+    return NextResponse.json({ status: result.status, approvals: result.approvals });
+  } catch (error: any) {
+    console.error('[api][secrets] failed to approve request', error);
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to approve request';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/apps/console/app/api/secrets/requests/route.ts
+++ b/apps/console/app/api/secrets/requests/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireStaff } from '../../../../lib/auth';
+import {
+  loadSecretRequests,
+  proposeCreate,
+  proposeReveal,
+  proposeRotate
+} from '../../../../server/secrets';
+
+function assertSecurityAdmin(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+const RequestSchema = z.object({
+  action: z.enum(['create', 'rotate', 'reveal']),
+  key: z.string().min(3).max(200),
+  env: z.string().min(1).max(64).default('prod'),
+  plaintext: z.string().optional(),
+  reason: z.string().min(5).max(2000),
+  aad: z.string().max(500).optional().nullable()
+});
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const staffUser = await requireStaff();
+  if (!assertSecurityAdmin(staffUser.roles)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    const requests = await loadSecretRequests(100);
+    return NextResponse.json({ requests });
+  } catch (error) {
+    console.error('[api][secrets] failed to list requests', error);
+    return NextResponse.json({ error: 'Failed to load secret requests' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const staffUser = await requireStaff();
+  if (!assertSecurityAdmin(staffUser.roles)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request payload' }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+
+  try {
+    let requestId: string;
+    switch (payload.action) {
+      case 'create':
+        if (!payload.plaintext) {
+          return NextResponse.json({ error: 'Plaintext required for create' }, { status: 400 });
+        }
+        requestId = await proposeCreate(
+          payload.key,
+          payload.env,
+          payload.plaintext,
+          payload.reason,
+          staffUser.id,
+          { aad: payload.aad ?? null }
+        );
+        break;
+      case 'rotate':
+        if (!payload.plaintext) {
+          return NextResponse.json({ error: 'Plaintext required for rotate' }, { status: 400 });
+        }
+        requestId = await proposeRotate(
+          payload.key,
+          payload.env,
+          payload.plaintext,
+          payload.reason,
+          staffUser.id,
+          { aad: payload.aad ?? null }
+        );
+        break;
+      case 'reveal':
+        requestId = await proposeReveal(payload.key, payload.env, payload.reason, staffUser.id);
+        break;
+      default:
+        return NextResponse.json({ error: 'Unsupported action' }, { status: 400 });
+    }
+
+    return NextResponse.json({ requestId });
+  } catch (error: any) {
+    console.error('[api][secrets] failed to create request', error);
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to create request';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/apps/console/app/api/secrets/reveal/route.ts
+++ b/apps/console/app/api/secrets/reveal/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireStaff } from '../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { consumeReveal, getDecrypted, maskSecretTail } from '../../../../server/secrets';
+
+const RevealSchema = z.object({
+  requestId: z.string().uuid()
+});
+
+function assertSecurityAdmin(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const staffUser = await requireStaff();
+  if (!assertSecurityAdmin(staffUser.roles)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const parsed = RevealSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request payload' }, { status: 400 });
+  }
+
+  const requestId = parsed.data.requestId;
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data: requestRow, error: requestError } = await (supabase.from('secret_change_requests') as any)
+    .select('id, key, env, action, status, applied_at, reason, requested_by')
+    .eq('id', requestId)
+    .maybeSingle();
+
+  if (requestError && requestError.code !== 'PGRST116') {
+    console.error('[api][secrets] failed to load reveal request', requestError);
+    return NextResponse.json({ error: 'Failed to load reveal request' }, { status: 500 });
+  }
+
+  if (!requestRow) {
+    return NextResponse.json({ error: 'Reveal request not found' }, { status: 404 });
+  }
+
+  if (requestRow.action !== 'reveal') {
+    return NextResponse.json({ error: 'Request is not a reveal action' }, { status: 400 });
+  }
+
+  const reveal = await consumeReveal(requestId, staffUser.id);
+  if (reveal) {
+    return NextResponse.json({
+      plaintext: reveal.plaintext,
+      key: reveal.key,
+      env: reveal.env
+    });
+  }
+
+  try {
+    const plaintext = await getDecrypted(requestRow.key, requestRow.env, {
+      skipAudit: true,
+      skipTouch: true
+    });
+    return NextResponse.json({ masked: maskSecretTail(plaintext), status: requestRow.status });
+  } catch (error) {
+    console.warn('[api][secrets] failed to mask reveal payload', error);
+    return NextResponse.json({ masked: '••••', status: requestRow.status });
+  }
+}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -73,6 +73,8 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       { href: '/admin/roles', label: 'Roles' },
       { href: '/admin/integrations', label: 'Integrations' },
       { href: '/admin/integrations/intake', label: 'Intake Webhooks' },
+      { href: '/admin/secrets', label: 'Secrets' },
+      { href: '/admin/secrets/approvals', label: 'Secret Approvals' },
       { href: '/staff', label: 'Staff' }
     ];
 

--- a/apps/console/components/admin/SecretApprovals.tsx
+++ b/apps/console/components/admin/SecretApprovals.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+
+type ApprovalRecord = {
+  id: string;
+  approver_user_id: string;
+  created_at: string;
+};
+
+type RequestRecord = {
+  id: string;
+  key: string;
+  env: string;
+  action: 'create' | 'rotate' | 'reveal';
+  reason: string;
+  requested_by: string;
+  status: 'pending' | 'approved' | 'rejected' | 'applied' | 'expired';
+  created_at: string;
+  applied_at: string | null;
+  approvals: ApprovalRecord[];
+};
+
+type SecretApprovalsProps = {
+  requests: RequestRecord[];
+};
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+function describeAction(action: RequestRecord['action']): string {
+  switch (action) {
+    case 'create':
+      return 'Create secret';
+    case 'rotate':
+      return 'Rotate secret';
+    case 'reveal':
+      return 'Reveal secret';
+    default:
+      return action;
+  }
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
+}
+
+export function SecretApprovals({ requests }: SecretApprovalsProps) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusMessage>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  async function approveRequest(event: FormEvent<HTMLFormElement>, requestId: string) {
+    event.preventDefault();
+    if (pendingId) {
+      return;
+    }
+
+    setPendingId(requestId);
+    setStatus(null);
+
+    try {
+      const response = await fetch(`/api/secrets/requests/${requestId}/approve`, {
+        method: 'POST'
+      });
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? 'Failed to approve request.';
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      setStatus({ type: 'success', message: 'Approval recorded.' });
+      router.refresh();
+    } catch (error) {
+      console.error('[secrets] approval error', error);
+      setStatus({ type: 'error', message: 'Unexpected error approving request.' });
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 rounded-3xl border border-slate-800 bg-slate-950/60 p-8 shadow-xl">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-100">Secret approvals</h1>
+        <p className="text-sm text-slate-400">
+          Dual-control changes require two distinct administrators. Review pending requests and approve when ready.
+        </p>
+      </div>
+
+      {status && (
+        <div
+          className={clsx(
+            'rounded-2xl border px-4 py-3 text-sm',
+            status.type === 'success'
+              ? 'border-emerald-600/60 bg-emerald-500/10 text-emerald-100'
+              : 'border-rose-600/60 bg-rose-500/10 text-rose-100'
+          )}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <section className="rounded-2xl border border-slate-800/60 overflow-hidden">
+        <table className="min-w-full divide-y divide-slate-800/80 text-sm text-slate-200">
+          <thead className="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th className="px-4 py-3 text-left">Secret</th>
+              <th className="px-4 py-3 text-left">Action</th>
+              <th className="px-4 py-3 text-left">Reason</th>
+              <th className="px-4 py-3 text-left">Status</th>
+              <th className="px-4 py-3 text-left">Approvals</th>
+              <th className="px-4 py-3 text-left">Requested</th>
+              <th className="px-4 py-3 text-right">Approve</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/80">
+            {requests.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-10 text-center text-sm text-slate-400">
+                  No requests awaiting action.
+                </td>
+              </tr>
+            ) : (
+              requests.map((request) => {
+                const isPending = pendingId === request.id;
+                const approvalCount = request.approvals.length;
+                return (
+                  <tr key={request.id} className="transition hover:bg-slate-800/40">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-semibold text-slate-100">{request.key}</span>
+                        <span className="text-xs uppercase tracking-wide text-slate-400">{request.env}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">{describeAction(request.action)}</td>
+                    <td className="px-4 py-3 text-slate-400">
+                      <span className="line-clamp-3 whitespace-pre-wrap break-words text-xs text-slate-300">
+                        {request.reason}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">{request.status}</td>
+                    <td className="px-4 py-3 text-slate-300">{approvalCount} / 2</td>
+                    <td className="px-4 py-3 text-slate-400">{formatTimestamp(request.created_at)}</td>
+                    <td className="px-4 py-3 text-right">
+                      <form onSubmit={(event) => approveRequest(event, request.id)}>
+                        <button
+                          type="submit"
+                          disabled={request.status !== 'pending' || isPending}
+                          className={clsx(
+                            'rounded-lg px-3 py-1 text-xs font-semibold text-slate-100 transition focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900',
+                            request.status === 'pending'
+                              ? 'bg-emerald-500 hover:bg-emerald-400 text-emerald-950'
+                              : 'bg-slate-800 text-slate-400 cursor-not-allowed',
+                            isPending && 'opacity-60'
+                          )}
+                        >
+                          {request.status === 'pending' ? (isPending ? 'Approving…' : 'Approve') : 'Completed'}
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/apps/console/components/admin/SecretsManager.tsx
+++ b/apps/console/components/admin/SecretsManager.tsx
@@ -1,0 +1,627 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+
+type SecretRecord = {
+  key: string;
+  env: string;
+  version: number;
+  lastRotatedAt: string | null;
+  lastAccessedAt: string | null;
+  requiresDualControl: boolean;
+};
+
+type ApprovalRecord = {
+  id: string;
+  approver_user_id: string;
+  created_at: string;
+};
+
+type RequestRecord = {
+  id: string;
+  key: string;
+  env: string;
+  action: 'create' | 'rotate' | 'reveal';
+  reason: string;
+  requested_by: string;
+  status: 'pending' | 'approved' | 'rejected' | 'applied' | 'expired';
+  created_at: string;
+  applied_at: string | null;
+  approvals: ApprovalRecord[];
+};
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+type SecretsManagerProps = {
+  secrets: SecretRecord[];
+  requests: RequestRecord[];
+};
+
+type PendingAction =
+  | { type: 'rotate'; secret: SecretRecord }
+  | { type: 'reveal'; secret: SecretRecord }
+  | null;
+
+type RevealResult =
+  | { requestId: string; plaintext: string; key: string; env: string }
+  | { requestId: string; masked: string; status: string };
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
+}
+
+function describeAction(action: RequestRecord['action']): string {
+  switch (action) {
+    case 'create':
+      return 'Create';
+    case 'rotate':
+      return 'Rotate';
+    case 'reveal':
+      return 'Reveal';
+    default:
+      return action;
+  }
+}
+
+export function SecretsManager({ secrets, requests }: SecretsManagerProps) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusMessage>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [pending, setPending] = useState(false);
+  const [revealPendingId, setRevealPendingId] = useState<string | null>(null);
+  const [revealResult, setRevealResult] = useState<RevealResult | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  const [createKey, setCreateKey] = useState('');
+  const [createEnv, setCreateEnv] = useState('prod');
+  const [createReason, setCreateReason] = useState('');
+  const [createPlaintext, setCreatePlaintext] = useState('');
+  const [createAad, setCreateAad] = useState('');
+
+  const [actionReason, setActionReason] = useState('');
+  const [actionPlaintext, setActionPlaintext] = useState('');
+  const [actionAad, setActionAad] = useState('');
+
+  function resetActionForm() {
+    setPendingAction(null);
+    setActionReason('');
+    setActionPlaintext('');
+    setActionAad('');
+  }
+
+  async function submitCreateSecret(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (pending) {
+      return;
+    }
+
+    setPending(true);
+    setStatus(null);
+
+    try {
+      const response = await fetch('/api/secrets/requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'create',
+          key: createKey.trim(),
+          env: createEnv.trim() || 'prod',
+          reason: createReason.trim(),
+          plaintext: createPlaintext,
+          aad: createAad.trim() || undefined
+        })
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = (payload as any)?.error ?? 'Failed to propose secret creation.';
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      setStatus({ type: 'success', message: 'Secret creation request submitted for approval.' });
+      setCreateKey('');
+      setCreateEnv('prod');
+      setCreateReason('');
+      setCreatePlaintext('');
+      setCreateAad('');
+      router.refresh();
+    } catch (error) {
+      console.error('[secrets] create proposal failed', error);
+      setStatus({ type: 'error', message: 'Unexpected error creating secret.' });
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function submitAction(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!pendingAction || pending) {
+      return;
+    }
+
+    setPending(true);
+    setStatus(null);
+
+    try {
+      const payload: Record<string, unknown> = {
+        action: pendingAction.type,
+        key: pendingAction.secret.key,
+        env: pendingAction.secret.env,
+        reason: actionReason.trim()
+      };
+
+      if (pendingAction.type === 'rotate') {
+        payload.plaintext = actionPlaintext;
+        if (actionAad.trim()) {
+          payload.aad = actionAad.trim();
+        }
+      }
+
+      const response = await fetch('/api/secrets/requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      const json = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = (json as any)?.error ?? 'Failed to submit request.';
+        setStatus({ type: 'error', message });
+        return;
+      }
+
+      const successMessage =
+        pendingAction.type === 'rotate'
+          ? 'Rotation request submitted for approval.'
+          : 'Reveal request submitted for approval.';
+      setStatus({ type: 'success', message: successMessage });
+      resetActionForm();
+      router.refresh();
+    } catch (error) {
+      console.error('[secrets] action proposal failed', error);
+      setStatus({ type: 'error', message: 'Unexpected error submitting request.' });
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function viewReveal(request: RequestRecord) {
+    if (revealPendingId) {
+      return;
+    }
+
+    setRevealPendingId(request.id);
+    setStatus(null);
+    setRevealResult(null);
+    try {
+      const response = await fetch('/api/secrets/reveal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: request.id })
+      });
+      const payload = await response.json().catch(() => null);
+
+      if (response.ok && payload && typeof (payload as any).plaintext === 'string') {
+        setRevealResult({
+          requestId: request.id,
+          plaintext: (payload as any).plaintext as string,
+          key: (payload as any).key as string,
+          env: (payload as any).env as string
+        });
+        setCopyFeedback('idle');
+      } else {
+        const masked = (payload as any)?.masked ?? '••••';
+        const statusValue = (payload as any)?.status ?? request.status;
+        setRevealResult({ requestId: request.id, masked, status: statusValue });
+        setStatus({ type: 'error', message: 'Reveal not available. Request may be pending approval or expired.' });
+      }
+    } catch (error) {
+      console.error('[secrets] reveal retrieval failed', error);
+      setStatus({ type: 'error', message: 'Unable to retrieve secret reveal.' });
+    } finally {
+      setRevealPendingId(null);
+    }
+  }
+
+  async function copyPlaintext() {
+    if (!revealResult || !('plaintext' in revealResult)) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(revealResult.plaintext);
+      setCopyFeedback('copied');
+      setTimeout(() => setCopyFeedback('idle'), 2000);
+    } catch (error) {
+      console.error('[secrets] failed to copy plaintext', error);
+      setCopyFeedback('error');
+    }
+  }
+
+  function acknowledgeReveal() {
+    setRevealResult(null);
+    setCopyFeedback('idle');
+    router.refresh();
+    setStatus({ type: 'success', message: 'Secret reveal acknowledged.' });
+  }
+
+  return (
+    <div className="flex flex-col gap-8 rounded-3xl border border-slate-800 bg-slate-950/60 p-8 shadow-xl">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-100">Secrets</h1>
+        <p className="text-sm text-slate-400">
+          Secrets are encrypted and protected by dual-control. Create or rotate secrets by submitting a request that
+          requires two administrators to approve.
+        </p>
+      </div>
+
+      {status && (
+        <div
+          className={clsx(
+            'rounded-2xl border px-4 py-3 text-sm',
+            status.type === 'success'
+              ? 'border-emerald-600/60 bg-emerald-500/10 text-emerald-100'
+              : 'border-rose-600/60 bg-rose-500/10 text-rose-100'
+          )}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <section className="rounded-2xl border border-slate-800/60 bg-slate-900/50 p-6">
+        <h2 className="text-xl font-semibold text-slate-100">Propose new secret</h2>
+        <p className="mt-1 text-sm text-slate-400">
+          Plaintext is encrypted immediately on submission and requires two approvals before activation.
+        </p>
+        <form onSubmit={submitCreateSecret} className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm text-slate-300">
+            <span>Secret key</span>
+            <input
+              required
+              value={createKey}
+              onChange={(event) => setCreateKey(event.target.value)}
+              placeholder="slack.webhook.prod"
+              className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-300">
+            <span>Environment</span>
+            <input
+              value={createEnv}
+              onChange={(event) => setCreateEnv(event.target.value)}
+              placeholder="prod"
+              className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            />
+          </label>
+          <label className="md:col-span-2 flex flex-col gap-2 text-sm text-slate-300">
+            <span>Reason</span>
+            <input
+              required
+              value={createReason}
+              onChange={(event) => setCreateReason(event.target.value)}
+              placeholder="Initial Slack webhook configuration"
+              className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            />
+          </label>
+          <label className="md:col-span-2 flex flex-col gap-2 text-sm text-slate-300">
+            <span>Plaintext secret</span>
+            <textarea
+              required
+              value={createPlaintext}
+              onChange={(event) => setCreatePlaintext(event.target.value)}
+              placeholder="Webhook URL or API key"
+              rows={4}
+              className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            />
+          </label>
+          <label className="md:col-span-2 flex flex-col gap-2 text-sm text-slate-300">
+            <span>Associated data (optional)</span>
+            <input
+              value={createAad}
+              onChange={(event) => setCreateAad(event.target.value)}
+              placeholder="Metadata bound via AES-GCM AAD"
+              className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+            />
+          </label>
+          <div className="md:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={pending}
+              className={clsx(
+                'rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-slate-900',
+                pending && 'opacity-60'
+              )}
+            >
+              {pending ? 'Submitting…' : 'Submit for approval'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-2xl border border-slate-800/60 overflow-hidden">
+        <table className="min-w-full divide-y divide-slate-800/80 text-sm text-slate-200">
+          <thead className="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left">
+                Secret
+              </th>
+              <th scope="col" className="px-4 py-3 text-left">
+                Version
+              </th>
+              <th scope="col" className="px-4 py-3 text-left">
+                Last rotated
+              </th>
+              <th scope="col" className="px-4 py-3 text-left">
+                Last accessed
+              </th>
+              <th scope="col" className="px-4 py-3 text-right" colSpan={2}>
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/80">
+            {secrets.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-10 text-center text-sm text-slate-400">
+                  No secrets stored yet.
+                </td>
+              </tr>
+            ) : (
+              secrets.map((secret) => {
+                return (
+                  <tr key={`${secret.key}:${secret.env}`} className="transition hover:bg-slate-800/40">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-semibold text-slate-100">{secret.key}</span>
+                        <span className="text-xs uppercase tracking-wide text-slate-400">{secret.env}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">{secret.version}</td>
+                    <td className="px-4 py-3 text-slate-400">{formatTimestamp(secret.lastRotatedAt)}</td>
+                    <td className="px-4 py-3 text-slate-400">{formatTimestamp(secret.lastAccessedAt)}</td>
+                    <td className="px-2 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setPendingAction({ type: 'rotate', secret });
+                          setActionReason('');
+                          setActionPlaintext('');
+                          setActionAad('');
+                        }}
+                        className="rounded-lg px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+                      >
+                        Propose rotation
+                      </button>
+                    </td>
+                    <td className="px-2 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setPendingAction({ type: 'reveal', secret });
+                          setActionReason('');
+                          setActionPlaintext('');
+                          setActionAad('');
+                        }}
+                        className="rounded-lg px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+                      >
+                        Propose reveal
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      {pendingAction && (
+        <section className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-6">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-100">
+                {pendingAction.type === 'rotate' ? 'Propose rotation' : 'Propose reveal'} — {pendingAction.secret.key}{' '}
+                <span className="text-xs uppercase text-slate-400">({pendingAction.secret.env})</span>
+              </h3>
+              <p className="mt-1 text-sm text-slate-400">
+                Provide a reason to notify approvers. Rotation requests must include the new plaintext value.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={resetActionForm}
+              className="rounded-lg px-3 py-1 text-xs font-semibold text-slate-300 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-slate-900"
+            >
+              Cancel
+            </button>
+          </div>
+          <form onSubmit={submitAction} className="mt-4 grid gap-4">
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              <span>Reason</span>
+              <input
+                required
+                value={actionReason}
+                onChange={(event) => setActionReason(event.target.value)}
+                placeholder="Explain why this change is required"
+                className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            {pendingAction.type === 'rotate' && (
+              <>
+                <label className="flex flex-col gap-2 text-sm text-slate-300">
+                  <span>New plaintext secret</span>
+                  <textarea
+                    required
+                    value={actionPlaintext}
+                    onChange={(event) => setActionPlaintext(event.target.value)}
+                    placeholder="New secret value"
+                    rows={4}
+                    className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm text-slate-300">
+                  <span>Associated data (optional)</span>
+                  <input
+                    value={actionAad}
+                    onChange={(event) => setActionAad(event.target.value)}
+                    placeholder="AAD value"
+                    className="rounded-lg border border-slate-700 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none"
+                  />
+                </label>
+              </>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="submit"
+                disabled={pending}
+                className={clsx(
+                  'rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-slate-900',
+                  pending && 'opacity-60'
+                )}
+              >
+                {pending ? 'Submitting…' : 'Submit request'}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      <section className="rounded-2xl border border-slate-800/60 overflow-hidden">
+        <h2 className="px-4 pt-4 text-xl font-semibold text-slate-100">Recent requests</h2>
+        <table className="mt-4 min-w-full divide-y divide-slate-800/80 text-sm text-slate-200">
+          <thead className="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th className="px-4 py-3 text-left">Secret</th>
+              <th className="px-4 py-3 text-left">Action</th>
+              <th className="px-4 py-3 text-left">Status</th>
+              <th className="px-4 py-3 text-left">Requested</th>
+              <th className="px-4 py-3 text-left">Approvals</th>
+              <th className="px-4 py-3 text-right">Reveal</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/80">
+            {requests.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-400">
+                  No requests yet.
+                </td>
+              </tr>
+            ) : (
+              requests.map((request) => {
+                return (
+                  <tr key={request.id} className="transition hover:bg-slate-800/40">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-semibold text-slate-100">{request.key}</span>
+                        <span className="text-xs uppercase tracking-wide text-slate-400">{request.env}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">{describeAction(request.action)}</td>
+                    <td className="px-4 py-3 text-slate-300">{request.status}</td>
+                    <td className="px-4 py-3 text-slate-400">{formatTimestamp(request.created_at)}</td>
+                    <td className="px-4 py-3 text-slate-300">{request.approvals.length} / 2</td>
+                    <td className="px-4 py-3 text-right">
+                      {request.action === 'reveal' ? (
+                        <button
+                          type="button"
+                          onClick={() => viewReveal(request)}
+                          disabled={request.status !== 'approved' && request.status !== 'applied'}
+                          className={clsx(
+                            'rounded-lg px-3 py-1 text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900',
+                            request.status === 'approved' || request.status === 'applied'
+                              ? 'bg-emerald-500 text-emerald-950 hover:bg-emerald-400'
+                              : 'bg-slate-800 text-slate-400 cursor-not-allowed',
+                            revealPendingId === request.id && 'opacity-60'
+                          )}
+                        >
+                          {request.status === 'approved'
+                            ? revealPendingId === request.id
+                              ? 'Fetching…'
+                              : 'Reveal secret'
+                            : request.status === 'applied'
+                            ? 'Revealed'
+                            : 'Waiting'}
+                        </button>
+                      ) : (
+                        <span className="text-xs text-slate-500">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      {revealResult && 'plaintext' in revealResult && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4">
+          <div className="w-full max-w-xl rounded-3xl border border-emerald-600/40 bg-slate-900/95 p-6 shadow-2xl">
+            <h3 className="text-xl font-semibold text-emerald-100">
+              Secret revealed — {revealResult.key}
+              <span className="ml-2 text-xs uppercase tracking-wide text-emerald-300">{revealResult.env}</span>
+            </h3>
+            <p className="mt-1 text-sm text-slate-300">
+              This secret is only visible for a short period. Copy it to a secure location, then acknowledge once it has
+              been stored safely.
+            </p>
+            <pre className="mt-4 max-h-48 overflow-auto rounded-xl border border-slate-700 bg-slate-950/90 p-4 text-sm text-slate-100">
+              {revealResult.plaintext}
+            </pre>
+            <div className="mt-4 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={copyPlaintext}
+                className="rounded-lg bg-slate-800 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+              >
+                {copyFeedback === 'copied'
+                  ? 'Copied!'
+                  : copyFeedback === 'error'
+                  ? 'Copy failed'
+                  : 'Copy to clipboard'}
+              </button>
+              <button
+                type="button"
+                onClick={acknowledgeReveal}
+                className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-slate-900"
+              >
+                I have stored this securely
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {revealResult && 'masked' in revealResult && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/60 p-4">
+          <div className="w-full max-w-md rounded-3xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
+            <h3 className="text-lg font-semibold text-slate-100">Reveal unavailable</h3>
+            <p className="mt-2 text-sm text-slate-300">
+              This reveal request is not currently available. Latest masked value:
+            </p>
+            <div className="mt-3 rounded-xl border border-slate-700 bg-slate-950/80 px-4 py-3 text-sm text-slate-200">
+              {revealResult.masked}
+            </div>
+            <button
+              type="button"
+              onClick={() => setRevealResult(null)}
+              className="mt-4 rounded-lg bg-slate-800 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-slate-900"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/console/server/crypto.ts
+++ b/apps/console/server/crypto.ts
@@ -1,0 +1,73 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+function getKey(): Buffer {
+  const key = process.env.TORVUS_KMS_KEY;
+  if (!key) {
+    throw new Error('TORVUS_KMS_KEY is not configured');
+  }
+
+  let decoded: Buffer;
+  try {
+    decoded = Buffer.from(key, 'base64');
+  } catch (error) {
+    throw new Error('TORVUS_KMS_KEY is not valid base64');
+  }
+
+  if (decoded.length !== 32) {
+    throw new Error('TORVUS_KMS_KEY must decode to 32 bytes for AES-256-GCM');
+  }
+
+  return decoded;
+}
+
+function normaliseAad(aad?: string): Buffer | null {
+  if (!aad) {
+    return null;
+  }
+  const trimmed = aad.trim();
+  return trimmed ? Buffer.from(trimmed, 'utf8') : null;
+}
+
+export function encrypt(plaintext: string, aad?: string): { ciphertext: Buffer; iv: Buffer } {
+  if (typeof plaintext !== 'string') {
+    throw new Error('encrypt() requires plaintext string');
+  }
+
+  const key = getKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const aadBuffer = normaliseAad(aad);
+  if (aadBuffer) {
+    cipher.setAAD(aadBuffer);
+  }
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return { ciphertext: Buffer.concat([encrypted, authTag]), iv };
+}
+
+export function decrypt(ciphertext: Buffer, iv: Buffer, aad?: string): string {
+  if (!Buffer.isBuffer(ciphertext) || ciphertext.length < 17) {
+    throw new Error('decrypt() requires ciphertext with auth tag');
+  }
+  if (!Buffer.isBuffer(iv) || iv.length < 12) {
+    throw new Error('decrypt() requires 12 byte iv');
+  }
+
+  const key = getKey();
+  const authTag = ciphertext.subarray(ciphertext.length - 16);
+  const encrypted = ciphertext.subarray(0, ciphertext.length - 16);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  const aadBuffer = normaliseAad(aad);
+  if (aadBuffer) {
+    decipher.setAAD(aadBuffer);
+  }
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+export function generateIv(): Buffer {
+  return randomBytes(12);
+}

--- a/apps/console/server/secrets.ts
+++ b/apps/console/server/secrets.ts
@@ -1,0 +1,724 @@
+import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { encrypt, decrypt } from './crypto';
+import { logAudit } from './audit';
+
+export type SecretRow = {
+  id: string;
+  key: string;
+  env: string;
+  description: string | null;
+  ciphertext: string;
+  iv: string;
+  aad: string | null;
+  version: number;
+  requires_dual_control: boolean;
+  created_by: string;
+  created_at: string;
+  last_rotated_at: string | null;
+  last_accessed_at: string | null;
+};
+
+export type SecretChangeRequestRow = {
+  id: string;
+  key: string;
+  env: string;
+  action: 'create' | 'rotate' | 'reveal';
+  proposed_ciphertext: string | null;
+  proposed_iv: string | null;
+  proposed_aad: string | null;
+  reason: string;
+  requested_by: string;
+  status: 'pending' | 'approved' | 'rejected' | 'applied' | 'expired';
+  created_at: string;
+  applied_at: string | null;
+};
+
+export type SecretChangeApprovalRow = {
+  id: string;
+  request_id: string;
+  approver_user_id: string;
+  created_at: string;
+};
+
+type HexString = `\\x${string}`;
+
+function toPgBytea(buffer: Buffer): HexString {
+  return `\\x${buffer.toString('hex')}`;
+}
+
+function fromPgBytea(value: string | null): Buffer {
+  if (!value) {
+    return Buffer.alloc(0);
+  }
+  const trimmed = value.startsWith('\\x') ? value.slice(2) : value;
+  return Buffer.from(trimmed, 'hex');
+}
+
+function normaliseKey(key: string): string {
+  const trimmed = key.trim();
+  if (!trimmed) {
+    throw new Error('Secret key is required');
+  }
+  return trimmed;
+}
+
+function normaliseEnv(env?: string): string {
+  const trimmed = env?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : 'prod';
+}
+
+function normaliseReason(reason: string): string {
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    throw new Error('Reason is required');
+  }
+  return trimmed.slice(0, 2000);
+}
+
+type ProposalOptions = {
+  aad?: string | null;
+  description?: string | null;
+};
+
+export async function proposeCreate(
+  key: string,
+  env: string,
+  plaintext: string,
+  reason: string,
+  requestedBy: string,
+  options?: ProposalOptions
+): Promise<string> {
+  const normalisedKey = normaliseKey(key);
+  const normalisedEnv = normaliseEnv(env);
+  const normalisedReason = normaliseReason(reason);
+  const aad = options?.aad ?? null;
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const existing = await (supabase.from('secrets') as any)
+    .select('id')
+    .eq('key', normalisedKey)
+    .eq('env', normalisedEnv)
+    .maybeSingle();
+
+  if (existing.error && existing.error.code !== 'PGRST116') {
+    console.error('[secrets] failed to check existing secret', existing.error);
+    throw new Error('Failed to evaluate existing secret');
+  }
+
+  if (existing.data) {
+    throw new Error('Secret already exists for this environment');
+  }
+
+  const { ciphertext, iv } = encrypt(plaintext, aad ?? undefined);
+
+  const { data, error } = await (supabase.from('secret_change_requests') as any)
+    .insert({
+      key: normalisedKey,
+      env: normalisedEnv,
+      action: 'create',
+      proposed_ciphertext: toPgBytea(ciphertext),
+      proposed_iv: toPgBytea(iv),
+      proposed_aad: aad ?? null,
+      reason: normalisedReason,
+      requested_by: requestedBy
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('[secrets] failed to create secret request', error);
+    throw new Error('Failed to create secret request');
+  }
+
+  const requestId = data.id as string;
+
+  try {
+    await logAudit({
+      action: 'secret.request_created',
+      targetType: 'secret',
+      targetId: `${normalisedKey}:${normalisedEnv}`,
+      meta: { action: 'create' }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for create request', auditError);
+  }
+
+  return requestId;
+}
+
+export async function proposeRotate(
+  key: string,
+  env: string,
+  plaintext: string,
+  reason: string,
+  requestedBy: string,
+  options?: ProposalOptions
+): Promise<string> {
+  const normalisedKey = normaliseKey(key);
+  const normalisedEnv = normaliseEnv(env);
+  const normalisedReason = normaliseReason(reason);
+  const aad = options?.aad ?? null;
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data: secretRow, error: secretError } = await (supabase.from('secrets') as any)
+    .select('id, version')
+    .eq('key', normalisedKey)
+    .eq('env', normalisedEnv)
+    .maybeSingle();
+
+  if (secretError && secretError.code !== 'PGRST116') {
+    console.error('[secrets] failed to load secret for rotation', secretError);
+    throw new Error('Failed to load secret for rotation');
+  }
+
+  if (!secretRow) {
+    throw new Error('Secret not found for rotation');
+  }
+
+  const { ciphertext, iv } = encrypt(plaintext, aad ?? undefined);
+
+  const { data, error } = await (supabase.from('secret_change_requests') as any)
+    .insert({
+      key: normalisedKey,
+      env: normalisedEnv,
+      action: 'rotate',
+      proposed_ciphertext: toPgBytea(ciphertext),
+      proposed_iv: toPgBytea(iv),
+      proposed_aad: aad ?? null,
+      reason: normalisedReason,
+      requested_by: requestedBy
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('[secrets] failed to create rotate request', error);
+    throw new Error('Failed to create secret rotation request');
+  }
+
+  const requestId = data.id as string;
+
+  try {
+    await logAudit({
+      action: 'secret.request_created',
+      targetType: 'secret',
+      targetId: `${normalisedKey}:${normalisedEnv}`,
+      meta: { action: 'rotate', current_version: secretRow.version }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for rotate request', auditError);
+  }
+
+  return requestId;
+}
+
+export async function proposeReveal(
+  key: string,
+  env: string,
+  reason: string,
+  requestedBy: string
+): Promise<string> {
+  const normalisedKey = normaliseKey(key);
+  const normalisedEnv = normaliseEnv(env);
+  const normalisedReason = normaliseReason(reason);
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data: secretRow, error: secretError } = await (supabase.from('secrets') as any)
+    .select('id, version')
+    .eq('key', normalisedKey)
+    .eq('env', normalisedEnv)
+    .maybeSingle();
+
+  if (secretError && secretError.code !== 'PGRST116') {
+    console.error('[secrets] failed to load secret for reveal', secretError);
+    throw new Error('Failed to load secret for reveal');
+  }
+
+  if (!secretRow) {
+    throw new Error('Secret not found for reveal');
+  }
+
+  const { data, error } = await (supabase.from('secret_change_requests') as any)
+    .insert({
+      key: normalisedKey,
+      env: normalisedEnv,
+      action: 'reveal',
+      reason: normalisedReason,
+      requested_by: requestedBy
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('[secrets] failed to create reveal request', error);
+    throw new Error('Failed to create secret reveal request');
+  }
+
+  const requestId = data.id as string;
+
+  try {
+    await logAudit({
+      action: 'secret.request_created',
+      targetType: 'secret',
+      targetId: `${normalisedKey}:${normalisedEnv}`,
+      meta: { action: 'reveal' }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for reveal request', auditError);
+  }
+
+  return requestId;
+}
+
+async function recordApproval(
+  request: SecretChangeRequestRow,
+  approverUserId: string
+): Promise<{ approvals: SecretChangeApprovalRow[]; request: SecretChangeRequestRow } | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const insertResult = await (supabase.from('secret_change_approvals') as any)
+    .insert({ request_id: request.id, approver_user_id: approverUserId })
+    .select('id, request_id, approver_user_id, created_at')
+    .single();
+
+  if (insertResult.error) {
+    if (insertResult.error.code === '23505') {
+      return null;
+    }
+    console.error('[secrets] failed to record approval', insertResult.error);
+    throw new Error('Failed to record approval');
+  }
+
+  const { data: approvalsData, error: approvalsError } = await (supabase
+    .from('secret_change_approvals') as any)
+    .select('id, request_id, approver_user_id, created_at')
+    .eq('request_id', request.id);
+
+  if (approvalsError) {
+    console.error('[secrets] failed to load approvals', approvalsError);
+    throw new Error('Failed to load approvals');
+  }
+
+  const approvals = (approvalsData as SecretChangeApprovalRow[] | null) ?? [];
+  return { approvals, request };
+}
+
+async function applyCreate(
+  request: SecretChangeRequestRow,
+  approvals: SecretChangeApprovalRow[]
+): Promise<void> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const ciphertext = fromPgBytea(request.proposed_ciphertext);
+  const iv = fromPgBytea(request.proposed_iv);
+
+  if (!ciphertext.length || !iv.length) {
+    throw new Error('Create request missing ciphertext');
+  }
+
+  const insertPayload = {
+    key: request.key,
+    env: request.env,
+    ciphertext: toPgBytea(ciphertext),
+    iv: toPgBytea(iv),
+    aad: request.proposed_aad,
+    created_by: request.requested_by,
+    requires_dual_control: true,
+    description: null
+  };
+
+  const { error: insertError } = await (supabase.from('secrets') as any)
+    .insert(insertPayload)
+    .select('id')
+    .single();
+
+  if (insertError) {
+    console.error('[secrets] failed to apply create request', insertError);
+    throw new Error('Failed to apply secret create request');
+  }
+
+  const { error: updateRequestError } = await (supabase.from('secret_change_requests') as any)
+    .update({ status: 'applied', applied_at: new Date().toISOString() })
+    .eq('id', request.id);
+
+  if (updateRequestError) {
+    console.error('[secrets] failed to update create request status', updateRequestError);
+  }
+
+  try {
+    await logAudit({
+      action: 'secret.applied',
+      targetType: 'secret',
+      targetId: `${request.key}:${request.env}`,
+      meta: { action: 'create', approvals: approvals.map((approval) => approval.approver_user_id) }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for applied create', auditError);
+  }
+}
+
+async function applyRotate(
+  request: SecretChangeRequestRow,
+  approvals: SecretChangeApprovalRow[]
+): Promise<void> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const ciphertext = fromPgBytea(request.proposed_ciphertext);
+  const iv = fromPgBytea(request.proposed_iv);
+
+  if (!ciphertext.length || !iv.length) {
+    throw new Error('Rotate request missing ciphertext');
+  }
+
+  const { data: currentRow, error: currentError } = await (supabase.from('secrets') as any)
+    .select('id, version')
+    .eq('key', request.key)
+    .eq('env', request.env)
+    .maybeSingle();
+
+  if (currentError && currentError.code !== 'PGRST116') {
+    console.error('[secrets] failed to load current secret for rotation', currentError);
+    throw new Error('Failed to load secret for rotation');
+  }
+
+  if (!currentRow) {
+    throw new Error('Secret not found during rotation');
+  }
+
+  const nextVersion = (currentRow.version as number) + 1;
+  const now = new Date().toISOString();
+
+  const { error: updateError } = await (supabase.from('secrets') as any)
+    .update({
+      ciphertext: toPgBytea(ciphertext),
+      iv: toPgBytea(iv),
+      aad: request.proposed_aad,
+      version: nextVersion,
+      last_rotated_at: now
+    })
+    .eq('id', currentRow.id);
+
+  if (updateError) {
+    console.error('[secrets] failed to update secret during rotation', updateError);
+    throw new Error('Failed to update secret during rotation');
+  }
+
+  const { error: requestUpdateError } = await (supabase.from('secret_change_requests') as any)
+    .update({ status: 'applied', applied_at: now })
+    .eq('id', request.id);
+
+  if (requestUpdateError) {
+    console.error('[secrets] failed to update rotation request status', requestUpdateError);
+  }
+
+  try {
+    await logAudit({
+      action: 'secret.applied',
+      targetType: 'secret',
+      targetId: `${request.key}:${request.env}`,
+      meta: { action: 'rotate', approvals: approvals.map((approval) => approval.approver_user_id), version: nextVersion }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for applied rotation', auditError);
+  }
+}
+
+async function markRevealApproved(requestId: string): Promise<void> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const now = new Date().toISOString();
+
+  const { error } = await (supabase.from('secret_change_requests') as any)
+    .update({ status: 'approved', applied_at: now })
+    .eq('id', requestId);
+
+  if (error) {
+    console.error('[secrets] failed to mark reveal approved', error);
+  }
+}
+
+export async function approve(
+  requestId: string,
+  approverUserId: string
+): Promise<{ status: 'pending' | 'approved' | 'applied'; approvals: SecretChangeApprovalRow[] }> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data: requestData, error: requestError } = await (supabase.from('secret_change_requests') as any)
+    .select(
+      'id, key, env, action, proposed_ciphertext, proposed_iv, proposed_aad, reason, requested_by, status, created_at, applied_at'
+    )
+    .eq('id', requestId)
+    .maybeSingle();
+
+  if (requestError && requestError.code !== 'PGRST116') {
+    console.error('[secrets] failed to load request for approval', requestError);
+    throw new Error('Failed to load request');
+  }
+
+  if (!requestData) {
+    throw new Error('Secret request not found');
+  }
+
+  const requestRow = requestData as SecretChangeRequestRow;
+
+  if (requestRow.requested_by === approverUserId) {
+    throw new Error('Requester cannot approve their own request');
+  }
+
+  if (requestRow.status !== 'pending') {
+    if (requestRow.action === 'reveal' && requestRow.status === 'approved') {
+      return { status: 'approved', approvals: [] };
+    }
+    if (requestRow.status === 'applied') {
+      return { status: 'applied', approvals: [] };
+    }
+    throw new Error('Request is not pending');
+  }
+
+  const recorded = await recordApproval(requestRow, approverUserId);
+  if (!recorded) {
+    throw new Error('Approval already recorded for this user');
+  }
+
+  const approvals = recorded.approvals;
+
+  try {
+    await logAudit({
+      action: 'secret.approved',
+      targetType: 'secret',
+      targetId: `${requestRow.key}:${requestRow.env}`,
+      meta: { action: requestRow.action, approver: approverUserId, approvals: approvals.length }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for approval', auditError);
+  }
+
+  if (approvals.length < 2) {
+    return { status: 'pending', approvals };
+  }
+
+  switch (requestRow.action) {
+    case 'create':
+      await applyCreate(requestRow, approvals);
+      return { status: 'applied', approvals };
+    case 'rotate':
+      await applyRotate(requestRow, approvals);
+      return { status: 'applied', approvals };
+    case 'reveal':
+      await markRevealApproved(requestRow.id);
+      return { status: 'approved', approvals };
+    default:
+      throw new Error(`Unsupported action ${requestRow.action}`);
+  }
+}
+
+export async function getDecrypted(
+  key: string,
+  env?: string,
+  options?: { requestId?: string; skipAudit?: boolean; skipTouch?: boolean }
+): Promise<string> {
+  const normalisedKey = normaliseKey(key);
+  const normalisedEnv = normaliseEnv(env);
+  const supabase = createSupabaseServiceRoleClient<any>();
+
+  const { data, error } = await (supabase.from('secrets') as any)
+    .select('id, ciphertext, iv, aad')
+    .eq('key', normalisedKey)
+    .eq('env', normalisedEnv)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('[secrets] failed to load secret for decryption', error);
+    throw new Error('Failed to load secret');
+  }
+
+  if (!data) {
+    throw new Error('Secret not found');
+  }
+
+  const secretRow = data as { id: string; ciphertext: string; iv: string; aad: string | null };
+  const plaintext = decrypt(fromPgBytea(secretRow.ciphertext), fromPgBytea(secretRow.iv), secretRow.aad ?? undefined);
+
+  if (!options?.skipTouch) {
+    const { error: updateError } = await (supabase.from('secrets') as any)
+      .update({ last_accessed_at: new Date().toISOString() })
+      .eq('id', secretRow.id);
+
+    if (updateError) {
+      console.warn('[secrets] failed to update last accessed timestamp', updateError);
+    }
+  }
+
+  if (!options?.skipAudit) {
+    try {
+      await logAudit({
+        action: 'secret.retrieved',
+        targetType: 'secret',
+        targetId: `${normalisedKey}:${normalisedEnv}`,
+        meta: options?.requestId ? { request_id: options.requestId } : undefined
+      });
+    } catch (auditError) {
+      console.warn('[secrets] failed to log audit for retrieval', auditError);
+    }
+  }
+
+  return plaintext;
+}
+
+export function maskSecretTail(value: string, visible = 4): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '••••';
+  }
+  if (trimmed.length <= visible) {
+    return '••••';
+  }
+  return `••••${trimmed.slice(-visible)}`;
+}
+
+export async function loadSecretsSummary(): Promise<
+  Array<{
+    key: string;
+    env: string;
+    version: number;
+    lastRotatedAt: string | null;
+    lastAccessedAt: string | null;
+    requiresDualControl: boolean;
+  }>
+> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('secrets') as any)
+    .select('key, env, version, last_rotated_at, last_accessed_at, requires_dual_control')
+    .order('key', { ascending: true })
+    .order('env', { ascending: true });
+
+  if (error) {
+    console.error('[secrets] failed to load secrets summary', error);
+    throw new Error('Failed to load secrets');
+  }
+
+  const rows = (data as Array<{
+    key: string;
+    env: string;
+    version: number;
+    last_rotated_at: string | null;
+    last_accessed_at: string | null;
+    requires_dual_control: boolean;
+  }> | null) ?? [];
+
+  return rows.map((row) => ({
+    key: row.key,
+    env: row.env,
+    version: row.version,
+    lastRotatedAt: row.last_rotated_at,
+    lastAccessedAt: row.last_accessed_at,
+    requiresDualControl: Boolean(row.requires_dual_control)
+  }));
+}
+
+export async function loadSecretRequests(limit = 50): Promise<
+  Array<
+    SecretChangeRequestRow & {
+      approvals: SecretChangeApprovalRow[];
+    }
+  >
+> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('secret_change_requests') as any)
+    .select('id, key, env, action, reason, requested_by, status, created_at, applied_at')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error('[secrets] failed to load change requests', error);
+    throw new Error('Failed to load secret requests');
+  }
+
+  const requests = (data as SecretChangeRequestRow[] | null) ?? [];
+  if (!requests.length) {
+    return [];
+  }
+
+  const requestIds = requests.map((request) => request.id);
+  const { data: approvalsData, error: approvalsError } = await (supabase
+    .from('secret_change_approvals') as any)
+    .select('id, request_id, approver_user_id, created_at')
+    .in('request_id', requestIds);
+
+  if (approvalsError) {
+    console.error('[secrets] failed to load approvals', approvalsError);
+    throw new Error('Failed to load approvals');
+  }
+
+  const approvals = (approvalsData as SecretChangeApprovalRow[] | null) ?? [];
+  const grouped = new Map<string, SecretChangeApprovalRow[]>();
+  for (const approval of approvals) {
+    const list = grouped.get(approval.request_id) ?? [];
+    list.push(approval);
+    grouped.set(approval.request_id, list);
+  }
+
+  return requests.map((request) => ({
+    ...request,
+    approvals: grouped.get(request.id) ?? []
+  }));
+}
+
+export async function consumeReveal(
+  requestId: string,
+  requesterUserId: string
+): Promise<{ plaintext: string; key: string; env: string } | null> {
+  const supabase = createSupabaseServiceRoleClient<any>();
+  const { data, error } = await (supabase.from('secret_change_requests') as any)
+    .select('id, key, env, action, status, applied_at, requested_by')
+    .eq('id', requestId)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('[secrets] failed to load reveal request', error);
+    throw new Error('Failed to load reveal request');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const request = data as SecretChangeRequestRow;
+
+  if (request.action !== 'reveal' || request.status !== 'approved') {
+    return null;
+  }
+
+  const approvedAt = request.applied_at ? new Date(request.applied_at) : null;
+  if (!approvedAt || Number.isNaN(approvedAt.getTime())) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (now - approvedAt.getTime() > 10 * 60 * 1000) {
+    return null;
+  }
+
+  const plaintext = await getDecrypted(request.key, request.env, {
+    requestId: request.id,
+    skipAudit: true
+  });
+
+  const { error: updateError } = await (supabase.from('secret_change_requests') as any)
+    .update({ status: 'applied' })
+    .eq('id', request.id);
+
+  if (updateError) {
+    console.error('[secrets] failed to mark reveal as applied', updateError);
+  }
+
+  try {
+    await logAudit({
+      action: 'secret.revealed',
+      targetType: 'secret',
+      targetId: `${request.key}:${request.env}`,
+      meta: { request_id: request.id, requester: requesterUserId }
+    });
+  } catch (auditError) {
+    console.warn('[secrets] failed to log audit for reveal', auditError);
+  }
+
+  return { plaintext, key: request.key, env: request.env };
+}

--- a/supabase/migrations/20250928_dual_control_secrets.sql
+++ b/supabase/migrations/20250928_dual_control_secrets.sql
@@ -1,0 +1,55 @@
+-- Dual-control secrets infrastructure (Feature 15)
+create table if not exists public.secrets (
+  id uuid primary key default gen_random_uuid(),
+  key text not null,
+  env text not null default 'prod',
+  description text null,
+  ciphertext bytea not null,
+  iv bytea not null,
+  aad text null,
+  version int not null default 1,
+  requires_dual_control boolean not null default true,
+  created_by uuid not null references auth.users(id),
+  created_at timestamptz not null default now(),
+  last_rotated_at timestamptz null,
+  last_accessed_at timestamptz null,
+  unique (key, env)
+);
+
+create index if not exists secrets_key_env_idx on public.secrets (key, env);
+
+create table if not exists public.secret_change_requests (
+  id uuid primary key default gen_random_uuid(),
+  key text not null,
+  env text not null default 'prod',
+  action text not null check (action in ('create','rotate','reveal')),
+  proposed_ciphertext bytea null,
+  proposed_iv bytea null,
+  proposed_aad text null,
+  reason text not null,
+  requested_by uuid not null references auth.users(id),
+  status text not null default 'pending' check (status in ('pending','approved','rejected','applied','expired')),
+  created_at timestamptz not null default now(),
+  applied_at timestamptz null
+);
+
+create index if not exists secret_change_requests_status_created_at_idx
+  on public.secret_change_requests (status, created_at desc);
+
+create table if not exists public.secret_change_approvals (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null references public.secret_change_requests(id) on delete cascade,
+  approver_user_id uuid not null references auth.users(id),
+  created_at timestamptz not null default now(),
+  unique (request_id, approver_user_id)
+);
+
+create index if not exists secret_change_approvals_request_idx
+  on public.secret_change_approvals (request_id);
+
+alter table if exists public.outbound_webhooks
+  add column if not exists secret_key text null;
+
+create index if not exists outbound_webhooks_secret_key_idx
+  on public.outbound_webhooks (secret_key)
+  where secret_key is not null;


### PR DESCRIPTION
## Summary
- add Supabase tables for encrypted secrets, dual-control requests, and approval tracking
- implement AES-256-GCM helpers plus server-side flows for proposing, approving, rotating, and revealing secrets with audit logging
- expose admin APIs and UI for secret management/approvals and update integrations to reference stored webhook secrets

## Testing
- pnpm --filter @torvus/console lint
- pnpm --filter @torvus/console test

------
https://chatgpt.com/codex/tasks/task_b_68d0226bedfc832d833a597f6e27a02c