### PR TITLE
Add database verification checklists

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,20 @@
+# Database Verification Runbook
+
+Follow these steps in the Supabase SQL editor after applying a migration set.
+
+## 1. Structural checklist
+1. Open the SQL editor and paste the contents of [`db/verify/checklist.sql`](db/verify/checklist.sql).
+2. Execute the script.
+3. **Expected result:** the query returns **zero rows**. Any returned rows list missing tables, columns, indexes, or views that must be addressed before proceeding.
+
+## 2. Post-apply smoke checks
+1. Replace `{{EMAIL}}` in [`db/verify/post_apply_smoke.sql`](db/verify/post_apply_smoke.sql) with the staff email you want to inspect (lower/upper case does not matter).
+2. Run the entire script in the SQL editor.
+3. **Result set interpretation:**
+   - The first result set should be empty. If it contains rows, the named `staff_roles` seeds are missing.
+   - The second result set should list the five built-in roles with their descriptions/built-in flags.
+   - The third result set should be empty. If it returns a row, the `public.app_control` singleton is missing.
+   - The fourth result set should show the singleton record with `id = 1`, including its `read_only` status and message.
+   - The final result set lists the effective roles for the supplied email; it can be empty if the staff user has no active roles.
+
+4. Investigate and fix any discrepancies before sign-off.

--- a/db/verify/checklist.sql
+++ b/db/verify/checklist.sql
@@ -1,0 +1,275 @@
+-- Verify that all database structures referenced by the console exist.
+-- This script only returns rows when something is missing.
+
+with required_tables(schema_name, table_name) as (
+  values
+    ('public','staff_users'),
+    ('public','staff_roles'),
+    ('public','staff_role_members'),
+    ('public','staff_role_permissions'),
+    ('public','staff_permissions'),
+    ('public','staff_dual_control_requests'),
+    ('public','personal_access_tokens'),
+    ('public','audit_events'),
+    ('public','inbound_integrations'),
+    ('public','inbound_events'),
+    ('public','investigations'),
+    ('public','investigation_events'),
+    ('public','release_requests'),
+    ('public','release_approvals'),
+    ('public','notification_prefs'),
+    ('public','outbound_webhooks'),
+    ('public','secrets'),
+    ('public','secret_change_requests'),
+    ('public','secret_change_approvals'),
+    ('public','app_settings'),
+    ('public','elevation_requests'),
+    ('public','elevation_approvals'),
+    ('public','alerts'),
+    ('public','app_control')
+),
+required_columns(schema_name, table_name, column_name) as (
+  values
+    ('public','staff_users','user_id'),
+    ('public','staff_users','email'),
+    ('public','staff_users','display_name'),
+    ('public','staff_users','passkey_enrolled'),
+    ('public','staff_users','created_at'),
+    ('public','staff_roles','id'),
+    ('public','staff_roles','name'),
+    ('public','staff_roles','description'),
+    ('public','staff_roles','built_in'),
+    ('public','staff_role_members','id'),
+    ('public','staff_role_members','user_id'),
+    ('public','staff_role_members','role_id'),
+    ('public','staff_role_members','created_at'),
+    ('public','staff_role_members','valid_from'),
+    ('public','staff_role_members','valid_to'),
+    ('public','staff_role_members','granted_via'),
+    ('public','staff_role_members','justification'),
+    ('public','staff_role_members','ticket_url'),
+    ('public','staff_role_permissions','role_id'),
+    ('public','staff_role_permissions','permission_key'),
+    ('public','staff_permissions','key'),
+    ('public','staff_permissions','description'),
+    ('public','staff_dual_control_requests','id'),
+    ('public','staff_dual_control_requests','action_key'),
+    ('public','staff_dual_control_requests','payload'),
+    ('public','staff_dual_control_requests','correlation_id'),
+    ('public','staff_dual_control_requests','requested_by'),
+    ('public','staff_dual_control_requests','approved_by'),
+    ('public','staff_dual_control_requests','status'),
+    ('public','staff_dual_control_requests','requested_at'),
+    ('public','staff_dual_control_requests','approved_at'),
+    ('public','staff_dual_control_requests','executed_at'),
+    ('public','personal_access_tokens','id'),
+    ('public','personal_access_tokens','user_id'),
+    ('public','personal_access_tokens','name'),
+    ('public','personal_access_tokens','token_hash'),
+    ('public','personal_access_tokens','scopes'),
+    ('public','personal_access_tokens','created_at'),
+    ('public','personal_access_tokens','last_used_at'),
+    ('public','personal_access_tokens','expires_at'),
+    ('public','personal_access_tokens','revoked'),
+    ('public','audit_events','id'),
+    ('public','audit_events','happened_at'),
+    ('public','audit_events','actor_user_id'),
+    ('public','audit_events','actor_email'),
+    ('public','audit_events','actor_roles'),
+    ('public','audit_events','action'),
+    ('public','audit_events','target_type'),
+    ('public','audit_events','target_id'),
+    ('public','audit_events','resource'),
+    ('public','audit_events','ip'),
+    ('public','audit_events','user_agent'),
+    ('public','audit_events','meta'),
+    ('public','inbound_integrations','id'),
+    ('public','inbound_integrations','kind'),
+    ('public','inbound_integrations','name'),
+    ('public','inbound_integrations','secret_hash'),
+    ('public','inbound_integrations','secret_ciphertext'),
+    ('public','inbound_integrations','enabled'),
+    ('public','inbound_integrations','created_at'),
+    ('public','inbound_integrations','last_seen_at'),
+    ('public','inbound_events','id'),
+    ('public','inbound_events','integration_id'),
+    ('public','inbound_events','ext_id'),
+    ('public','inbound_events','dedup_hash'),
+    ('public','inbound_events','received_at'),
+    ('public','inbound_events','payload'),
+    ('public','investigations','id'),
+    ('public','investigations','created_at'),
+    ('public','investigations','updated_at'),
+    ('public','investigations','title'),
+    ('public','investigations','status'),
+    ('public','investigations','severity'),
+    ('public','investigations','opened_by'),
+    ('public','investigations','assigned_to'),
+    ('public','investigations','tags'),
+    ('public','investigations','summary'),
+    ('public','investigation_events','id'),
+    ('public','investigation_events','investigation_id'),
+    ('public','investigation_events','created_at'),
+    ('public','investigation_events','actor_user_id'),
+    ('public','investigation_events','kind'),
+    ('public','investigation_events','message'),
+    ('public','investigation_events','meta'),
+    ('public','release_requests','id'),
+    ('public','release_requests','title'),
+    ('public','release_requests','description'),
+    ('public','release_requests','requested_by'),
+    ('public','release_requests','status'),
+    ('public','release_requests','created_at'),
+    ('public','release_requests','last_decision_at'),
+    ('public','release_approvals','id'),
+    ('public','release_approvals','request_id'),
+    ('public','release_approvals','approver_id'),
+    ('public','release_approvals','decision'),
+    ('public','release_approvals','reason'),
+    ('public','release_approvals','created_at'),
+    ('public','notification_prefs','id'),
+    ('public','notification_prefs','event'),
+    ('public','notification_prefs','enabled'),
+    ('public','outbound_webhooks','id'),
+    ('public','outbound_webhooks','kind'),
+    ('public','outbound_webhooks','url'),
+    ('public','outbound_webhooks','enabled'),
+    ('public','outbound_webhooks','description'),
+    ('public','outbound_webhooks','created_at'),
+    ('public','outbound_webhooks','secret_key'),
+    ('public','secrets','id'),
+    ('public','secrets','key'),
+    ('public','secrets','env'),
+    ('public','secrets','description'),
+    ('public','secrets','ciphertext'),
+    ('public','secrets','iv'),
+    ('public','secrets','aad'),
+    ('public','secrets','version'),
+    ('public','secrets','requires_dual_control'),
+    ('public','secrets','created_by'),
+    ('public','secrets','created_at'),
+    ('public','secrets','last_rotated_at'),
+    ('public','secrets','last_accessed_at'),
+    ('public','secret_change_requests','id'),
+    ('public','secret_change_requests','key'),
+    ('public','secret_change_requests','env'),
+    ('public','secret_change_requests','action'),
+    ('public','secret_change_requests','proposed_ciphertext'),
+    ('public','secret_change_requests','proposed_iv'),
+    ('public','secret_change_requests','proposed_aad'),
+    ('public','secret_change_requests','reason'),
+    ('public','secret_change_requests','requested_by'),
+    ('public','secret_change_requests','status'),
+    ('public','secret_change_requests','created_at'),
+    ('public','secret_change_requests','applied_at'),
+    ('public','secret_change_approvals','id'),
+    ('public','secret_change_approvals','request_id'),
+    ('public','secret_change_approvals','approver_user_id'),
+    ('public','secret_change_approvals','created_at'),
+    ('public','app_settings','key'),
+    ('public','app_settings','value'),
+    ('public','app_settings','updated_at'),
+    ('public','app_settings','updated_by'),
+    ('public','elevation_requests','id'),
+    ('public','elevation_requests','created_at'),
+    ('public','elevation_requests','requested_by'),
+    ('public','elevation_requests','target_user_id'),
+    ('public','elevation_requests','roles'),
+    ('public','elevation_requests','reason'),
+    ('public','elevation_requests','ticket_url'),
+    ('public','elevation_requests','window_minutes'),
+    ('public','elevation_requests','status'),
+    ('public','elevation_requests','executed_at'),
+    ('public','elevation_approvals','id'),
+    ('public','elevation_approvals','request_id'),
+    ('public','elevation_approvals','approver_user_id'),
+    ('public','elevation_approvals','created_at'),
+    ('public','alerts','id'),
+    ('public','alerts','created_at'),
+    ('public','alerts','title'),
+    ('public','alerts','severity'),
+    ('public','alerts','source'),
+    ('public','alerts','status'),
+    ('public','alerts','owner_email'),
+    ('public','app_control','id'),
+    ('public','app_control','read_only'),
+    ('public','app_control','message')
+),
+required_indexes(schema_name, index_name) as (
+  values
+    ('public','idx_staff_role_members_user'),
+    ('public','idx_staff_role_members_role'),
+    ('public','staff_role_members_user_valid_to_via_idx'),
+    ('public','idx_dual_control_status'),
+    ('public','personal_access_tokens_user_id_idx'),
+    ('public','personal_access_tokens_revoked_expires_at_idx'),
+    ('public','personal_access_tokens_last_used_at_idx'),
+    ('public','idx_audit_events_happened_at_desc'),
+    ('public','idx_audit_events_action'),
+    ('public','idx_audit_events_actor_email'),
+    ('public','idx_audit_events_target'),
+    ('public','idx_inbound_events_integration_received_desc'),
+    ('public','idx_inbound_events_dedup_hash'),
+    ('public','idx_investigations_updated_at_desc'),
+    ('public','idx_investigation_events_investigation_created_desc'),
+    ('public','secret_change_requests_status_created_at_idx'),
+    ('public','secret_change_approvals_request_idx'),
+    ('public','outbound_webhooks_secret_key_idx'),
+    ('public','secrets_key_env_idx'),
+    ('public','elevation_requests_status_created_at_idx'),
+    ('public','alerts_status_created_at_idx')
+),
+required_views(schema_name, view_name) as (
+  values
+    ('public','v_investigations_list'),
+    ('public','investigation_events_with_actor'),
+    ('public','release_requests_with_counts')
+),
+missing_tables as (
+  select 'table' as object_type,
+         rt.schema_name || '.' || rt.table_name as object_name
+  from required_tables rt
+  left join information_schema.tables t
+    on t.table_schema = rt.schema_name
+   and t.table_name = rt.table_name
+  where t.table_name is null
+),
+missing_columns as (
+  select 'column' as object_type,
+         rc.schema_name || '.' || rc.table_name || '.' || rc.column_name as object_name
+  from required_columns rc
+  left join information_schema.columns c
+    on c.table_schema = rc.schema_name
+   and c.table_name = rc.table_name
+   and c.column_name = rc.column_name
+  where c.column_name is null
+),
+missing_indexes as (
+  select 'index' as object_type,
+         ri.schema_name || '.' || ri.index_name as object_name
+  from required_indexes ri
+  left join pg_indexes i
+    on i.schemaname = ri.schema_name
+   and i.indexname = ri.index_name
+  where i.indexname is null
+),
+missing_views as (
+  select 'view' as object_type,
+         rv.schema_name || '.' || rv.view_name as object_name
+  from required_views rv
+  left join information_schema.views v
+    on v.table_schema = rv.schema_name
+   and v.table_name = rv.view_name
+  where v.table_name is null
+)
+select *
+from (
+  select * from missing_tables
+  union all
+  select * from missing_columns
+  union all
+  select * from missing_indexes
+  union all
+  select * from missing_views
+) as missing
+order by object_type, object_name;

--- a/db/verify/post_apply_smoke.sql
+++ b/db/verify/post_apply_smoke.sql
@@ -1,0 +1,42 @@
+-- Post-apply smoke checks for Torvus Console schema.
+
+-- 1. Ensure built-in staff roles are present. Any rows returned indicate missing roles.
+with required_roles(role_name) as (
+  values
+    ('security_admin'),
+    ('auditor'),
+    ('investigator'),
+    ('operator'),
+    ('break_glass')
+)
+select 'missing_staff_role' as issue, rr.role_name as detail
+from required_roles rr
+left join public.staff_roles sr on sr.name = rr.role_name
+where sr.id is null;
+
+-- Helpful view of current role rows (should include all required roles above).
+select name, description, built_in
+from public.staff_roles
+where name in ('security_admin','auditor','investigator','operator','break_glass')
+order by name;
+
+-- 2. Verify the application control singleton row exists.
+select 'missing_app_control_row' as issue, 'public.app_control id=1' as detail
+where not exists (
+  select 1 from public.app_control where id = 1
+);
+
+select id, read_only, message
+from public.app_control
+where id = 1;
+
+-- 3. Resolve effective roles for the supplied email (replace {{EMAIL}} before running).
+select distinct sr.name as effective_role
+from public.staff_users su
+join public.staff_role_members srm on srm.user_id = su.user_id
+join public.staff_roles sr on sr.id = srm.role_id
+where lower(su.email) = lower('{{EMAIL}}')
+  and coalesce(srm.granted_via, 'normal') in ('normal','break_glass')
+  and coalesce(srm.valid_from, now()) <= now()
+  and (srm.valid_to is null or srm.valid_to > now())
+order by effective_role;


### PR DESCRIPTION
## Summary
- add a checklist SQL script that flags missing tables, columns, indexes and views required by the console
- add a post-apply smoke SQL script that verifies seed data and inspects effective roles for a supplied email
- document the exact Supabase SQL editor steps and expected outputs in RUNBOOK.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d118f11da0832da5413b1c75dda1cf