### PR TITLE
Add database maintenance backfill scripts

### DIFF
--- a/db/backfill/close_expired_elevation.sql
+++ b/db/backfill/close_expired_elevation.sql
@@ -1,0 +1,10 @@
+-- Mark expired elevation requests as expired to align status with their expiry timestamps.
+-- Run during low-traffic periods: psql -f db/backfill/close_expired_elevation.sql
+BEGIN;
+
+UPDATE elevation_requests
+SET status = 'expired'
+WHERE expires_at < NOW()
+  AND status IN ('pending', 'approved');
+
+COMMIT;

--- a/db/backfill/ensure_active_membership_integrity.sql
+++ b/db/backfill/ensure_active_membership_integrity.sql
@@ -1,0 +1,20 @@
+-- Close out older overlapping active staff role memberships to keep only the most recent one per role.
+-- Execute in a controlled window: psql -f db/backfill/ensure_active_membership_integrity.sql
+BEGIN;
+
+WITH ranked_memberships AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY staff_user_id, staff_role_id
+               ORDER BY COALESCE(valid_from, TIMESTAMP 'epoch') DESC, id DESC
+           ) AS rn
+    FROM staff_role_members
+    WHERE valid_to IS NULL
+)
+UPDATE staff_role_members srm
+SET valid_to = NOW()
+FROM ranked_memberships dupes
+WHERE srm.id = dupes.id
+  AND dupes.rn > 1;
+
+COMMIT;

--- a/db/backfill/normalize_emails.sql
+++ b/db/backfill/normalize_emails.sql
@@ -1,0 +1,24 @@
+-- Lower-case all existing staff user email addresses and add a guard to keep them normalized.
+-- Run inside a transaction in a maintenance window: psql -f db/backfill/normalize_emails.sql
+BEGIN;
+
+UPDATE staff_users
+SET email = LOWER(email)
+WHERE email <> LOWER(email);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'staff_users_email_lowercase_chk'
+          AND conrelid = 'staff_users'::regclass
+    ) THEN
+        EXECUTE 'ALTER TABLE staff_users
+                 ADD CONSTRAINT staff_users_email_lowercase_chk
+                 CHECK (email = lower(email))';
+    END IF;
+END
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add backfill script to normalize staff user emails and enforce lower-casing
- add script to expire stale elevation requests
- add script to close out duplicate active staff role memberships

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d121b2a508832db4f9c943679dd652