### PR TITLE
Add self-check endpoint and centralize access gating

### DIFF
--- a/apps/console/app/access-denied/page.tsx
+++ b/apps/console/app/access-denied/page.tsx
@@ -1,0 +1,5 @@
+import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+
+export default function AccessDeniedPage() {
+  return <AccessDeniedNotice />;
+}

--- a/apps/console/app/api/selfcheck/route.ts
+++ b/apps/console/app/api/selfcheck/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { evaluateAccessGate } from '../../../lib/authz/gate';
+import { verifyCfAccessAssertion } from '../../../lib/auth/cfAccess';
+
+function normaliseEmail(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function readAccessAssertion(request: Request): string | null {
+  const headerAssertion =
+    request.headers.get('Cf-Access-Jwt-Assertion') ?? request.headers.get('cf-access-jwt-assertion');
+
+  if (headerAssertion && headerAssertion.trim()) {
+    return headerAssertion.trim();
+  }
+
+  const cookieHeader = request.headers.get('cookie');
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed.startsWith('CF_Authorization=')) {
+      continue;
+    }
+    const token = trimmed.substring('CF_Authorization='.length).trim();
+    if (token) {
+      return token;
+    }
+  }
+
+  return null;
+}
+
+const DEFAULT_FLAGS = {
+  enrolled: false,
+  verified: false,
+  status: 'unknown',
+  passkey_enrolled: false
+} as const;
+
+export async function GET(request: Request) {
+  const assertion = readAccessAssertion(request);
+  if (!assertion) {
+    return NextResponse.json({
+      email: '',
+      allowed: false,
+      reasons: ['cloudflare access session required'],
+      flags: { ...DEFAULT_FLAGS },
+      roles: [] as string[]
+    });
+  }
+
+  const claims = await verifyCfAccessAssertion(assertion);
+  if (!claims) {
+    return NextResponse.json({
+      email: '',
+      allowed: false,
+      reasons: ['invalid cloudflare access assertion'],
+      flags: { ...DEFAULT_FLAGS },
+      roles: [] as string[]
+    });
+  }
+
+  const claimEmail = normaliseEmail(
+    (claims.email as string | undefined)
+      ?? (typeof claims.preferred_username === 'string' ? claims.preferred_username : undefined)
+      ?? (typeof claims.name === 'string' ? claims.name : undefined)
+  );
+
+  if (!claimEmail) {
+    return NextResponse.json({
+      email: '',
+      allowed: false,
+      reasons: ['unable to determine email from access assertion'],
+      flags: { ...DEFAULT_FLAGS },
+      roles: [] as string[]
+    });
+  }
+
+  try {
+    const evaluation = await evaluateAccessGate(claimEmail);
+    return NextResponse.json({
+      email: evaluation.email,
+      allowed: evaluation.allowed,
+      reasons: evaluation.reasons,
+      flags: evaluation.flags,
+      roles: evaluation.roles
+    });
+  } catch (error) {
+    console.error('[api:selfcheck] failed to evaluate access gate', error);
+    return NextResponse.json({
+      email: claimEmail,
+      allowed: false,
+      reasons: ['gate evaluation failed'],
+      flags: { ...DEFAULT_FLAGS },
+      roles: [] as string[]
+    });
+  }
+}

--- a/apps/console/lib/authz/gate.ts
+++ b/apps/console/lib/authz/gate.ts
@@ -1,0 +1,202 @@
+import { createSupabaseServiceRoleClient } from '../supabase';
+import type { PostgrestLikeOrSupabase } from '../types';
+
+function normaliseEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isDebugLoggingEnabled(): boolean {
+  return (process.env.LOG_LEVEL ?? '').toLowerCase() === 'debug';
+}
+
+export type AccessFlags = {
+  enrolled: boolean;
+  verified: boolean;
+  status: string;
+  passkey_enrolled: boolean;
+};
+
+export type AccessGateEvaluation = {
+  email: string;
+  userId: string | null;
+  displayName: string | null;
+  allowed: boolean;
+  reasons: string[];
+  flags: AccessFlags;
+  roles: string[];
+  roleIds: string[];
+};
+
+type StaffRoleMembershipRow = {
+  role_id: string | null;
+  valid_to: string | null;
+  staff_roles?: {
+    name: string | null;
+  } | null;
+} | null;
+
+type StaffUserRow = {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  enrolled: boolean | null;
+  verified: boolean | null;
+  status: string | null;
+  passkey_enrolled: boolean | null;
+  staff_role_members: StaffRoleMembershipRow[] | null;
+} | null;
+
+export async function evaluateAccessGate(
+  normalisedEmail: string,
+  options?: { client?: PostgrestLikeOrSupabase }
+): Promise<AccessGateEvaluation> {
+  const trimmedEmail = normalisedEmail.trim();
+  const email = trimmedEmail ? normaliseEmail(trimmedEmail) : '';
+
+  if (!email) {
+    const result: AccessGateEvaluation = {
+      email: '',
+      userId: null,
+      displayName: null,
+      allowed: false,
+      reasons: ['missing email'],
+      flags: {
+        enrolled: false,
+        verified: false,
+        status: 'unknown',
+        passkey_enrolled: false
+      },
+      roles: [],
+      roleIds: []
+    };
+
+    if (isDebugLoggingEnabled()) {
+      console.debug('[authz] gate deny', { email, reasons: result.reasons });
+    }
+
+    return result;
+  }
+
+  const supabase = (options?.client ?? createSupabaseServiceRoleClient()) as PostgrestLikeOrSupabase;
+
+  const query = (supabase.from('staff_users') as any)
+    .select(
+      `user_id,
+      email,
+      display_name,
+      enrolled,
+      verified,
+      status,
+      passkey_enrolled,
+      staff_role_members:staff_role_members!left(
+        role_id,
+        valid_to,
+        staff_roles:staff_roles ( name )
+      )`
+    )
+    .eq('email', email)
+    .is('staff_role_members.valid_to', null)
+    .maybeSingle();
+
+  const { data, error } = (await query) as {
+    data: StaffUserRow;
+    error: { code?: string } | null;
+  };
+
+  if (error && error.code !== 'PGRST116') {
+    throw error;
+  }
+
+  const staffRow = data ?? null;
+
+  const flags: AccessFlags = {
+    enrolled: Boolean(staffRow?.enrolled),
+    verified: Boolean(staffRow?.verified),
+    status: staffRow?.status?.trim() ?? 'unknown',
+    passkey_enrolled: Boolean(staffRow?.passkey_enrolled)
+  };
+
+  const memberships = (staffRow?.staff_role_members ?? []).filter((membership) => {
+    if (!membership) {
+      return false;
+    }
+
+    if (membership.valid_to) {
+      return false;
+    }
+
+    return Boolean(membership.role_id);
+  });
+
+  const roles = memberships
+    .map((membership) => membership?.staff_roles?.name?.trim())
+    .filter((role): role is string => Boolean(role));
+
+  const uniqueRoles = Array.from(new Set(roles));
+  uniqueRoles.sort((a, b) => a.localeCompare(b));
+
+  const roleIds = Array.from(
+    new Set(
+      memberships
+        .map((membership) => membership?.role_id)
+        .filter((roleId): roleId is string => Boolean(roleId))
+    )
+  );
+
+  const reasons: string[] = [];
+
+  if (!staffRow) {
+    reasons.push('staff record not found');
+  } else {
+    if (!flags.enrolled) {
+      reasons.push('enrollment incomplete');
+    }
+
+    if (!flags.verified) {
+      reasons.push('account not verified');
+    }
+
+    if (flags.status !== 'active') {
+      reasons.push(`staff status is ${flags.status}`);
+    }
+  }
+
+  const lowerRoles = uniqueRoles.map((role) => role.toLowerCase());
+  const hasSecurityAdmin = lowerRoles.includes('security_admin');
+  const hasAuditor = lowerRoles.includes('auditor');
+
+  if (staffRow && !hasSecurityAdmin && !hasAuditor) {
+    reasons.push('missing required role security_admin or auditor');
+  }
+
+  if (staffRow && !flags.passkey_enrolled) {
+    reasons.push('passkey enrollment pending (informational)');
+  }
+
+  const allowed =
+    staffRow !== null &&
+    flags.enrolled &&
+    flags.verified &&
+    flags.status === 'active' &&
+    (hasSecurityAdmin || hasAuditor);
+
+  if (!allowed && isDebugLoggingEnabled()) {
+    console.debug('[authz] gate deny', {
+      email,
+      reasons,
+      flags,
+      roles: uniqueRoles
+    });
+  }
+
+  return {
+    email,
+    userId: staffRow?.user_id ?? null,
+    displayName: staffRow?.display_name ?? null,
+    allowed,
+    reasons,
+    flags,
+    roles: uniqueRoles,
+    roleIds
+  };
+}

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -1,0 +1,3 @@
+export type PostgrestLikeOrSupabase = {
+  from: (table: string) => unknown;
+};

--- a/apps/console/tests/lib/auth.test.ts
+++ b/apps/console/tests/lib/auth.test.ts
@@ -44,16 +44,17 @@ describe('getUserRolesByEmail', () => {
     const maybeSingle = vi.fn(async () => ({
       data: {
         staff_role_members: [
-          { staff_roles: { name: 'security_admin' } },
-          { staff_roles: { name: 'investigator' } },
-          { staff_roles: { name: 'security_admin' } }
+          { staff_roles: { name: 'security_admin' }, role_id: '1', valid_to: null },
+          { staff_roles: { name: 'investigator' }, role_id: '2', valid_to: null },
+          { staff_roles: { name: 'security_admin' }, role_id: '1', valid_to: null }
         ]
       },
       error: null
     }));
 
-    const eq = vi.fn(() => ({ maybeSingle }));
-    const select = vi.fn(() => ({ eq }));
+    const isFn = vi.fn(() => ({ maybeSingle }));
+    const eq = vi.fn(() => ({ is: isFn, maybeSingle }));
+    const select = vi.fn(() => ({ eq, is: isFn, maybeSingle }));
     const from = vi.fn(() => ({ select }));
 
     const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];
@@ -62,6 +63,7 @@ describe('getUserRolesByEmail', () => {
 
     expect(from).toHaveBeenCalledWith('staff_users');
     expect(eq).toHaveBeenCalledWith('email', 'admin@example.com');
+    expect(isFn).toHaveBeenCalledWith('staff_role_members.valid_to', null);
     expect(roles).toEqual(['investigator', 'security_admin']);
   });
 
@@ -77,8 +79,9 @@ describe('getUserRolesByEmail', () => {
 
   it('returns empty array when record not found', async () => {
     const maybeSingle = vi.fn(async () => ({ data: null, error: { code: 'PGRST116' } }));
-    const eq = vi.fn(() => ({ maybeSingle }));
-    const select = vi.fn(() => ({ eq }));
+    const isFn = vi.fn(() => ({ maybeSingle }));
+    const eq = vi.fn(() => ({ is: isFn, maybeSingle }));
+    const select = vi.fn(() => ({ eq, is: isFn, maybeSingle }));
     const from = vi.fn(() => ({ select }));
 
     const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];

--- a/apps/console/tests/lib/auth.test.ts
+++ b/apps/console/tests/lib/auth.test.ts
@@ -41,30 +41,43 @@ describe('getRequesterEmail', () => {
 
 describe('getUserRolesByEmail', () => {
   it('returns sorted unique role names', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
     const maybeSingle = vi.fn(async () => ({
       data: {
         staff_role_members: [
-          { staff_roles: { name: 'security_admin' }, role_id: '1', valid_to: null },
+          {
+            staff_roles: { name: 'security_admin' },
+            role_id: '1',
+            valid_to: '2024-01-02T00:00:00Z'
+          },
           { staff_roles: { name: 'investigator' }, role_id: '2', valid_to: null },
-          { staff_roles: { name: 'security_admin' }, role_id: '1', valid_to: null }
+          {
+            staff_roles: { name: 'security_admin' },
+            role_id: '1',
+            valid_to: '2023-12-31T23:00:00Z'
+          }
         ]
       },
       error: null
     }));
 
-    const isFn = vi.fn(() => ({ maybeSingle }));
-    const eq = vi.fn(() => ({ is: isFn, maybeSingle }));
-    const select = vi.fn(() => ({ eq, is: isFn, maybeSingle }));
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq, maybeSingle }));
     const from = vi.fn(() => ({ select }));
 
     const client = { from } as unknown as Parameters<typeof getUserRolesByEmail>[1];
 
-    const roles = await getUserRolesByEmail('Admin@Example.com', client);
+    try {
+      const roles = await getUserRolesByEmail('Admin@Example.com', client);
 
-    expect(from).toHaveBeenCalledWith('staff_users');
-    expect(eq).toHaveBeenCalledWith('email', 'admin@example.com');
-    expect(isFn).toHaveBeenCalledWith('staff_role_members.valid_to', null);
-    expect(roles).toEqual(['investigator', 'security_admin']);
+      expect(from).toHaveBeenCalledWith('staff_users');
+      expect(eq).toHaveBeenCalledWith('email', 'admin@example.com');
+      expect(roles).toEqual(['investigator', 'security_admin']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns empty array when email missing', async () => {

--- a/apps/console/tests/lib/authz/gate.test.ts
+++ b/apps/console/tests/lib/authz/gate.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { evaluateAccessGate } from '../../../lib/authz/gate';
+import type { PostgrestLikeOrSupabase } from '../../../lib/types';
+
+type StubClient = PostgrestLikeOrSupabase & {
+  __internals: {
+    maybeSingle: ReturnType<typeof vi.fn>;
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    isFn: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createStubClient(data: unknown, error: unknown = null): StubClient {
+  const maybeSingle = vi.fn(async () => ({ data, error }));
+  const isFn = vi.fn(() => ({ maybeSingle }));
+  const eq = vi.fn(() => ({ is: isFn, maybeSingle }));
+  const select = vi.fn(() => ({ eq, is: isFn, maybeSingle }));
+  const from = vi.fn(() => ({ select }));
+
+  return {
+    from,
+    __internals: { maybeSingle, select, eq, isFn }
+  } as unknown as StubClient;
+}
+
+describe('evaluateAccessGate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows active, verified security admin', async () => {
+    const client = createStubClient({
+      user_id: 'user-123',
+      email: 'admin@example.com',
+      display_name: 'Admin Example',
+      enrolled: true,
+      verified: true,
+      status: 'active',
+      passkey_enrolled: true,
+      staff_role_members: [
+        {
+          role_id: 'role-1',
+          valid_to: null,
+          staff_roles: { name: 'security_admin' }
+        }
+      ]
+    });
+
+    const result = await evaluateAccessGate('Admin@Example.com', { client });
+
+    expect(client.from).toHaveBeenCalledWith('staff_users');
+    expect(result.allowed).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.flags).toEqual({
+      enrolled: true,
+      verified: true,
+      status: 'active',
+      passkey_enrolled: true
+    });
+    expect(result.roles).toEqual(['security_admin']);
+    expect(result.roleIds).toEqual(['role-1']);
+    expect(result.userId).toBe('user-123');
+    expect(result.displayName).toBe('Admin Example');
+  });
+
+  it('denies when not enrolled', async () => {
+    const client = createStubClient({
+      user_id: 'user-456',
+      email: 'pending@example.com',
+      display_name: null,
+      enrolled: false,
+      verified: true,
+      status: 'active',
+      passkey_enrolled: false,
+      staff_role_members: [
+        {
+          role_id: 'role-2',
+          valid_to: null,
+          staff_roles: { name: 'security_admin' }
+        }
+      ]
+    });
+
+    const result = await evaluateAccessGate('pending@example.com', { client });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reasons).toContain('enrollment incomplete');
+    expect(result.flags.enrolled).toBe(false);
+  });
+
+  it('denies when status not active', async () => {
+    const client = createStubClient({
+      user_id: 'user-789',
+      email: 'disabled@example.com',
+      display_name: null,
+      enrolled: true,
+      verified: true,
+      status: 'suspended',
+      passkey_enrolled: true,
+      staff_role_members: [
+        {
+          role_id: 'role-3',
+          valid_to: null,
+          staff_roles: { name: 'security_admin' }
+        }
+      ]
+    });
+
+    const result = await evaluateAccessGate('disabled@example.com', { client });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reasons).toContain('staff status is suspended');
+  });
+
+  it('denies when missing required role', async () => {
+    const client = createStubClient({
+      user_id: 'user-999',
+      email: 'observer@example.com',
+      display_name: null,
+      enrolled: true,
+      verified: true,
+      status: 'active',
+      passkey_enrolled: false,
+      staff_role_members: [
+        {
+          role_id: 'role-4',
+          valid_to: null,
+          staff_roles: { name: 'observer' }
+        }
+      ]
+    });
+
+    const result = await evaluateAccessGate('observer@example.com', { client });
+
+    expect(result.allowed).toBe(false);
+    expect(result.roles).toEqual(['observer']);
+    expect(result.reasons).toContain('missing required role security_admin or auditor');
+  });
+});


### PR DESCRIPTION
## Summary
- add a protected /api/selfcheck endpoint that reports the current access gate evaluation
- centralize the staff access gate logic and reuse it in middleware and helpers
- add unit tests and middleware routing for the new gate plus an access-denied landing page

## Testing
- pnpm --filter @torvus/console test

------
https://chatgpt.com/codex/tasks/task_b_68d3a2bda10c832d8dfc139d27791347