### PR TITLE
Add consistent loading skeletons and empty states to admin lists

### DIFF
--- a/apps/console/app/admin/people/page.tsx
+++ b/apps/console/app/admin/people/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { cookies, headers } from 'next/headers';
 import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
@@ -6,6 +7,8 @@ import { AppShell } from '../../../components/AppShell';
 import { Sidebar } from '../../../components/Sidebar';
 import { PageHeader } from '../../../components/PageHeader';
 import { InviteStaffButton } from '../../../components/actions/InviteStaffButton';
+import { SkeletonBlock } from '../../../components/SkeletonBlock';
+import { EmptyState } from '../../../components/EmptyState';
 import { PeopleTable, type AdminPersonRecord } from '../../../components/admin/PeopleTable';
 import { getStaffUser } from '../../../lib/auth';
 
@@ -51,6 +54,92 @@ async function fetchPeople(baseUrl: string, emailHeader: string | null): Promise
   return { status: 200, people };
 }
 
+function PeopleSkeleton() {
+  return (
+    <section
+      className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl"
+      aria-hidden="true"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <SkeletonBlock width="16rem" height="1.5rem" />
+        <SkeletonBlock width="12rem" height="2.5rem" />
+      </div>
+      <div className="overflow-hidden rounded-2xl border border-slate-800/60">
+        <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm">
+          <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              {[0, 1, 2, 3].map((key) => (
+                <th key={key} scope="col" className="px-6 py-3">
+                  <SkeletonBlock width="6rem" height="1rem" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <tr key={index}>
+                {Array.from({ length: 4 }).map((__unused, cellIndex) => (
+                  <td key={cellIndex} className="px-6 py-4">
+                    <SkeletonBlock height="1rem" />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+async function PeopleDirectorySection({
+  baseUrl,
+  headerEmail
+}: {
+  baseUrl: string;
+  headerEmail: string | null;
+}) {
+  let peopleResult: FetchPeopleResult;
+
+  try {
+    peopleResult = await fetchPeople(baseUrl, headerEmail);
+  } catch (error) {
+    console.error('failed to load staff directory', error);
+    return (
+      <Callout.Root color="crimson" role="alert">
+        <Flex align="center" justify="between" gap="3" wrap="wrap">
+          <Callout.Text>Unable to load the staff directory. Try again shortly.</Callout.Text>
+          <Button color="crimson" variant="soft" asChild>
+            <Link href="/admin/people">Retry</Link>
+          </Button>
+        </Flex>
+      </Callout.Root>
+    );
+  }
+
+  if (peopleResult.status === 401 || peopleResult.status === 403 || !peopleResult.people) {
+    return (
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
+    );
+  }
+
+  const people = peopleResult.people;
+
+  if (people.length === 0) {
+    return (
+      <EmptyState
+        title="Invite your first administrator"
+        description="Share Torvus Console with a teammate to collaborate on investigations."
+        action={<InviteStaffButton />}
+      />
+    );
+  }
+
+  return <PeopleTable people={people} />;
+}
+
 export default async function AdminPeoplePage() {
   const staffUser = await getStaffUser();
 
@@ -83,49 +172,6 @@ export default async function AdminPeoplePage() {
     ?? headerBag.get('x-session-user-email')
     ?? staffUser.email;
 
-  let peopleResult: FetchPeopleResult;
-
-  try {
-    peopleResult = await fetchPeople(baseUrl, headerEmail);
-  } catch (error) {
-    console.error('failed to load staff directory', error);
-    return (
-      <AppShell sidebar={<Sidebar />}>
-        <PageHeader
-          title="People"
-          subtitle="Security administrators enrolled in Torvus Console."
-          actions={(
-            <Flex align="center" gap="3" wrap="wrap">
-              <Text size="2" color="gray">
-                Signed in as {staffUser.displayName} ({staffUser.email})
-              </Text>
-              <InviteStaffButton />
-            </Flex>
-          )}
-        />
-        <Callout.Root color="crimson" role="alert">
-          <Flex align="center" justify="between" gap="3" wrap="wrap">
-            <Callout.Text>Unable to load the staff directory. Try again shortly.</Callout.Text>
-            <Button color="crimson" variant="soft" asChild>
-              <Link href="/admin/people">Retry</Link>
-            </Button>
-          </Flex>
-        </Callout.Root>
-      </AppShell>
-    );
-  }
-
-  if (peopleResult.status === 401 || peopleResult.status === 403 || !peopleResult.people) {
-    return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
-    );
-  }
-
-  const people = peopleResult.people;
   const headerActions = (
     <Flex align="center" gap="3" wrap="wrap">
       <Text size="2" color="gray">
@@ -142,17 +188,10 @@ export default async function AdminPeoplePage() {
         subtitle="Security administrators enrolled in Torvus Console."
         actions={headerActions}
       />
-
-      {people.length === 0 ? (
-        <Callout.Root color="gray" role="status">
-          <Flex align="center" justify="between" gap="3" wrap="wrap">
-            <Callout.Text>No staff have been added yet. Invite a teammate to get started.</Callout.Text>
-            <InviteStaffButton />
-          </Flex>
-        </Callout.Root>
-      ) : (
-        <PeopleTable people={people} />
-      )}
+      <Suspense fallback={<PeopleSkeleton />}>
+        {/* @ts-expect-error Async Server Component */}
+        <PeopleDirectorySection baseUrl={baseUrl} headerEmail={headerEmail} />
+      </Suspense>
     </AppShell>
   );
 }

--- a/apps/console/app/admin/roles/page.tsx
+++ b/apps/console/app/admin/roles/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { cookies, headers } from 'next/headers';
 import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
@@ -6,6 +7,7 @@ import { AppShell } from '../../../components/AppShell';
 import { Sidebar } from '../../../components/Sidebar';
 import { PageHeader } from '../../../components/PageHeader';
 import { ScrollToSectionButton } from '../../../components/actions/ScrollToSectionButton';
+import { SkeletonBlock } from '../../../components/SkeletonBlock';
 import { RoleManager, type RoleMemberRecord } from '../../../components/admin/RoleManager';
 import { getStaffUser } from '../../../lib/auth';
 
@@ -62,6 +64,96 @@ async function fetchRoles(baseUrl: string, emailHeader: string | null): Promise<
   return { status: 200, data: payload };
 }
 
+function RolesSkeleton() {
+  return (
+    <section
+      className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl"
+      aria-hidden="true"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <SkeletonBlock width="18rem" height="1.5rem" />
+        <SkeletonBlock width="12rem" height="2.5rem" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="overflow-hidden rounded-2xl border border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm">
+            <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+              <tr>
+                {[0, 1, 2].map((key) => (
+                  <th key={key} scope="col" className="px-6 py-3">
+                    <SkeletonBlock width="6rem" height="1rem" />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/60">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <tr key={index}>
+                  {Array.from({ length: 3 }).map((__unused, cellIndex) => (
+                    <td key={cellIndex} className="px-6 py-4">
+                      <SkeletonBlock height="1rem" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <aside className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/60 p-6">
+          <SkeletonBlock width="10rem" height="1.25rem" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="flex flex-col gap-2">
+                <SkeletonBlock width="5rem" height="1rem" />
+                <SkeletonBlock width="100%" height="2.5rem" />
+              </div>
+            ))}
+            <SkeletonBlock width="7rem" height="2.5rem" />
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+async function RolesDirectorySection({
+  baseUrl,
+  headerEmail
+}: {
+  baseUrl: string;
+  headerEmail: string | null;
+}) {
+  let rolesResult: FetchRolesResult;
+
+  try {
+    rolesResult = await fetchRoles(baseUrl, headerEmail);
+  } catch (error) {
+    console.error('failed to load roles', error);
+    return (
+      <Callout.Root color="crimson" role="alert">
+        <Flex align="center" justify="between" gap="3" wrap="wrap">
+          <Callout.Text>Unable to load role assignments. Try again shortly.</Callout.Text>
+          <Button color="crimson" variant="soft" asChild>
+            <Link href="/admin/roles">Retry</Link>
+          </Button>
+        </Flex>
+      </Callout.Root>
+    );
+  }
+
+  if (rolesResult.status === 401 || rolesResult.status === 403 || !rolesResult.data) {
+    return (
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
+    );
+  }
+
+  const data = rolesResult.data;
+
+  return <RoleManager roles={data.roles} members={data.members} />;
+}
+
 export default async function AdminRolesPage() {
   const staffUser = await getStaffUser();
 
@@ -94,49 +186,6 @@ export default async function AdminRolesPage() {
     ?? headerBag.get('x-session-user-email')
     ?? staffUser.email;
 
-  let rolesResult: FetchRolesResult;
-
-  try {
-    rolesResult = await fetchRoles(baseUrl, headerEmail);
-  } catch (error) {
-    console.error('failed to load roles', error);
-    return (
-      <AppShell sidebar={<Sidebar />}>
-        <PageHeader
-          title="Roles"
-          subtitle="Manage privileged assignments for staff."
-          actions={(
-            <Flex align="center" gap="3" wrap="wrap">
-              <Text size="2" color="gray">
-                Signed in as {staffUser.displayName} ({staffUser.email})
-              </Text>
-              <ScrollToSectionButton targetId="assign-role" label="Assign role" />
-            </Flex>
-          )}
-        />
-        <Callout.Root color="crimson" role="alert">
-          <Flex align="center" justify="between" gap="3" wrap="wrap">
-            <Callout.Text>Unable to load role assignments. Try again shortly.</Callout.Text>
-            <Button color="crimson" variant="soft" asChild>
-              <Link href="/admin/roles">Retry</Link>
-            </Button>
-          </Flex>
-        </Callout.Root>
-      </AppShell>
-    );
-  }
-
-  if (rolesResult.status === 401 || rolesResult.status === 403 || !rolesResult.data) {
-    return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
-    );
-  }
-
-  const data = rolesResult.data;
   const headerActions = (
     <Flex align="center" gap="3" wrap="wrap">
       <Text size="2" color="gray">
@@ -153,8 +202,10 @@ export default async function AdminRolesPage() {
         subtitle="Manage privileged assignments for staff."
         actions={headerActions}
       />
-
-      <RoleManager roles={data.roles} members={data.members} />
+      <Suspense fallback={<RolesSkeleton />}>
+        {/* @ts-expect-error Async Server Component */}
+        <RolesDirectorySection baseUrl={baseUrl} headerEmail={headerEmail} />
+      </Suspense>
     </AppShell>
   );
 }

--- a/apps/console/app/audit/AuditClient.tsx
+++ b/apps/console/app/audit/AuditClient.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { AuditMetaDetails } from '../../components/AuditMetaDetails';
+import { EmptyState } from '../../components/EmptyState';
+import { SkeletonBlock } from '../../components/SkeletonBlock';
 
 type RangeOption = '24h' | '7d' | '30d' | 'custom';
 
@@ -319,10 +321,15 @@ export function AuditClient({
       return (
         <tr>
           <td colSpan={6} className="empty">
-            <div className="muted text-center">
-              <p className="font-medium">No audit events found for the selected filters.</p>
-              <p className="text-sm">Adjust filters or broaden the date range to see more activity.</p>
-            </div>
+            <EmptyState
+              title="No audit events found"
+              description="Try adjusting the filters or expanding the date range to uncover more activity."
+              action={
+                <button type="button" className="button ghost" onClick={onClearFilters}>
+                  Reset filters
+                </button>
+              }
+            />
           </td>
         </tr>
       );
@@ -330,13 +337,12 @@ export function AuditClient({
 
     if (loading && events.length === 0) {
       return Array.from({ length: 6 }).map((_, index) => (
-        <tr key={`skeleton-${index}`} className="table-skeleton">
-          <td><span className="skeleton-line" /></td>
-          <td><span className="skeleton-line" /></td>
-          <td><span className="skeleton-line" /></td>
-          <td><span className="skeleton-line" /></td>
-          <td><span className="skeleton-line" /></td>
-          <td><span className="skeleton-line" /></td>
+        <tr key={`skeleton-${index}`} aria-hidden="true">
+          {Array.from({ length: 6 }).map((__unused, cellIndex) => (
+            <td key={cellIndex}>
+              <SkeletonBlock height="1rem" className="my-2" />
+            </td>
+          ))}
         </tr>
       ));
     }
@@ -367,7 +373,7 @@ export function AuditClient({
         </td>
       </tr>
     ));
-  }, [events, loading, error]);
+  }, [events, loading, error, onClearFilters]);
 
   return (
     <div className="audit-ledger">
@@ -494,7 +500,7 @@ export function AuditClient({
 
       {error ? <div className="alert error">{error}</div> : null}
 
-      <div className="table-wrapper" role="region" aria-live="polite">
+      <div className="table-wrapper" role="status" aria-live="polite">
         <table>
           <thead>
             <tr>

--- a/apps/console/app/profile/PersonalAccessTokensPanel.tsx
+++ b/apps/console/app/profile/PersonalAccessTokensPanel.tsx
@@ -11,6 +11,8 @@ import {
   type FormEvent
 } from 'react';
 import { Button, Callout, Flex } from '@radix-ui/themes';
+import { EmptyState } from '../../components/EmptyState';
+import { SkeletonBlock } from '../../components/SkeletonBlock';
 
 export type PersonalAccessToken = {
   id: string;
@@ -326,7 +328,11 @@ export const PersonalAccessTokensPanel = forwardRef<
   }, [tokens]);
 
   return (
-    <section className="flex flex-col gap-4 rounded-3xl border border-slate-700 bg-slate-900/60 p-6 shadow-lg">
+    <section
+      className="flex flex-col gap-4 rounded-3xl border border-slate-700 bg-slate-900/60 p-6 shadow-lg"
+      role="status"
+      aria-live="polite"
+    >
       {showHeader ? (
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-col">
@@ -354,18 +360,27 @@ export const PersonalAccessTokensPanel = forwardRef<
           </Callout.Root>
         ) : null}
         {loading ? (
-          <div className="rounded-2xl border border-slate-700/70 bg-slate-900/40 p-6 text-center text-sm text-slate-400">
-            Loading tokens…
+          <div className="rounded-2xl border border-slate-700/70 bg-slate-900/40 p-6" aria-hidden="true">
+            <div className="flex flex-col gap-4">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="flex flex-col gap-2 rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4">
+                  <SkeletonBlock width="12rem" height="1rem" />
+                  <SkeletonBlock width="16rem" height="0.75rem" />
+                  <SkeletonBlock width="8rem" height="0.75rem" />
+                </div>
+              ))}
+            </div>
           </div>
         ) : sortedTokens.length === 0 ? (
-          <Callout.Root color="gray" role="status">
-            <Flex align="center" justify="between" gap="3" wrap="wrap">
-              <Callout.Text>No tokens yet. Create one to automate workflows securely.</Callout.Text>
+          <EmptyState
+            title="No personal access tokens"
+            description="Create a token to generate API credentials tied to your account."
+            action={
               <Button color="iris" onClick={openCreate}>
                 Create token
               </Button>
-            </Flex>
-          </Callout.Root>
+            }
+          />
         ) : (
           <div className="flex flex-col gap-3">
             {sortedTokens.map((token) => (

--- a/apps/console/components/EmptyState.tsx
+++ b/apps/console/components/EmptyState.tsx
@@ -1,0 +1,26 @@
+import { Card, Flex, Heading, Text } from '@radix-ui/themes';
+import type { ReactNode } from 'react';
+
+export type EmptyStateProps = {
+  title: string;
+  description: string;
+  action?: ReactNode;
+};
+
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <Card role="status" aria-live="polite">
+      <Flex direction="column" gap="3">
+        <div>
+          <Heading as="h2" size="4">
+            {title}
+          </Heading>
+          <Text as="p" size="2" color="gray" mt="1">
+            {description}
+          </Text>
+        </div>
+        {action ? <div>{action}</div> : null}
+      </Flex>
+    </Card>
+  );
+}

--- a/apps/console/components/SkeletonBlock.tsx
+++ b/apps/console/components/SkeletonBlock.tsx
@@ -1,0 +1,29 @@
+import { Box, type BoxProps } from '@radix-ui/themes';
+import clsx from 'clsx';
+
+export type SkeletonBlockProps = BoxProps & {
+  width?: BoxProps['width'];
+  height?: BoxProps['height'];
+};
+
+export function SkeletonBlock({
+  width = '100%',
+  height = '1rem',
+  className,
+  style,
+  ...props
+}: SkeletonBlockProps) {
+  return (
+    <Box
+      aria-hidden="true"
+      {...props}
+      width={width}
+      height={height}
+      className={clsx('animate-pulse rounded-full', className)}
+      style={{
+        backgroundColor: 'var(--gray-4)',
+        ...style
+      }}
+    />
+  );
+}

--- a/apps/console/components/admin/PeopleTable.tsx
+++ b/apps/console/components/admin/PeopleTable.tsx
@@ -52,7 +52,11 @@ export function PeopleTable({ people }: PeopleTableProps) {
   const filtered = useMemo(() => filterPeople(people, query), [people, query]);
 
   return (
-    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+    <section
+      className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl"
+      role="status"
+      aria-live="polite"
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-400">Filter staff by email or display name.</p>
         <label

--- a/apps/console/components/admin/RoleManager.tsx
+++ b/apps/console/components/admin/RoleManager.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import clsx from 'clsx';
+import { EmptyState } from '../EmptyState';
+import { InviteStaffButton } from '../actions/InviteStaffButton';
 
 type RoleDefinition = {
   id: string;
@@ -227,7 +229,11 @@ export function RoleManager({ roles, members }: RoleManagerProps) {
   }
 
   return (
-    <section className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl">
+    <section
+      className="flex flex-col gap-6 rounded-3xl border border-slate-700 bg-slate-900/60 p-8 shadow-2xl"
+      role="status"
+      aria-live="polite"
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-400">Filter members by email or name.</p>
         <label
@@ -262,54 +268,64 @@ export function RoleManager({ roles, members }: RoleManagerProps) {
       ) : null}
 
       <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
-        <div className="overflow-hidden rounded-2xl border border-slate-800/70">
-          <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm text-slate-200">
-            <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
-              <tr>
-                <th scope="col" className="px-6 py-3">
-                  Email
-                </th>
-                <th scope="col" className="px-6 py-3">
-                  Display name
-                </th>
-                <th scope="col" className="px-6 py-3">
-                  Roles
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800/60">
-              {filteredMembers.length === 0 ? (
-                <tr>
-                  <td colSpan={3} className="px-6 py-12 text-center text-sm text-slate-400">
-                    No staff members match your filter.
-                  </td>
-                </tr>
-              ) : (
-                filteredMembers.map((member) => (
-                  <tr key={member.user_id} className="transition hover:bg-slate-800/40">
-                    <td className="px-6 py-4 text-sm font-medium text-slate-100">{member.email}</td>
-                    <td className="px-6 py-4 text-sm text-slate-300">{member.display_name ?? '—'}</td>
-                    <td className="px-6 py-4">
-                      <div className="flex flex-wrap gap-2">
-                        {member.roles.length ? (
-                          member.roles.map((role) => (
-                            <RoleChip
-                              key={`${member.user_id}-${role}`}
-                              role={role}
-                              disabled={pendingAction !== null}
-                              onRemove={() => removeRole(member.user_id, role)}
-                            />
-                          ))
-                        ) : (
-                          <span className="text-xs text-slate-500">—</span>
-                        )}
-                      </div>
-                    </td>
+        <div className="flex flex-col gap-4">
+          {records.length === 0 ? (
+            <EmptyState
+              title="No staff yet"
+              description="Invite administrators before assigning roles."
+              action={<InviteStaffButton />}
+            />
+          ) : (
+            <div className="overflow-hidden rounded-2xl border border-slate-800/70">
+              <table className="min-w-full divide-y divide-slate-800/80 text-left text-sm text-slate-200">
+                <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+                  <tr>
+                    <th scope="col" className="px-6 py-3">
+                      Email
+                    </th>
+                    <th scope="col" className="px-6 py-3">
+                      Display name
+                    </th>
+                    <th scope="col" className="px-6 py-3">
+                      Roles
+                    </th>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
+                </thead>
+                <tbody className="divide-y divide-slate-800/60">
+                  {filteredMembers.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="px-6 py-12 text-center text-sm text-slate-400">
+                        No staff members match your filter.
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredMembers.map((member) => (
+                      <tr key={member.user_id} className="transition hover:bg-slate-800/40">
+                        <td className="px-6 py-4 text-sm font-medium text-slate-100">{member.email}</td>
+                        <td className="px-6 py-4 text-sm text-slate-300">{member.display_name ?? '—'}</td>
+                        <td className="px-6 py-4">
+                          <div className="flex flex-wrap gap-2">
+                            {member.roles.length ? (
+                              member.roles.map((role) => (
+                                <RoleChip
+                                  key={`${member.user_id}-${role}`}
+                                  role={role}
+                                  disabled={pendingAction !== null}
+                                  onRemove={() => removeRole(member.user_id, role)}
+                                />
+                              ))
+                            ) : (
+                              <span className="text-xs text-slate-500">—</span>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
 
         <aside


### PR DESCRIPTION
## Summary
- add shared `SkeletonBlock` and `EmptyState` components for consistent loading and empty experiences
- wrap admin list pages in suspense with skeleton fallbacks and live regions for accessible updates
- refresh token and audit tables to use the shared skeletons and guided empty messaging

## Testing
- pnpm --filter console lint

------
https://chatgpt.com/codex/tasks/task_b_68d3d37ceeb8832da9b0e2cdc5090469