### PR TITLE
Gracefully handle missing Supabase configuration in console

### DIFF
--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -12,6 +12,7 @@ import '../styles/tokens.css';
 import '../styles/globals.css';
 import { getStaffUser } from '../lib/auth';
 import { buildNavItems, getAnalyticsClient } from '../lib/analytics';
+import { isSupabaseConfigured } from '../lib/supabase';
 import { formatBreadcrumb } from '../lib/breadcrumbs';
 import { IdentityPill } from '../components/IdentityPill';
 import { AccessDeniedNotice } from '../components/AccessDeniedNotice';
@@ -35,7 +36,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
 
   const showMinimalShell = pathname.startsWith('/enroll-passkey');
 
-  const staffUser = await getStaffUser();
+  const supabaseConfigured = isSupabaseConfigured();
 
   const themeProps = {
     appearance: 'dark' as const,
@@ -45,6 +46,27 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     radius: 'large' as const,
     scaling: '100%' as const
   };
+
+  if (!supabaseConfigured) {
+    return (
+      <html lang="en" data-theme="torvus-staff">
+        <body data-correlation={correlationId} className="body-minimal">
+          <Theme {...themeProps}>
+            <div className="unauthorised" role="alert">
+              <h1>Torvus Console</h1>
+              <p>Supabase configuration is required before the console can be used.</p>
+              <p className="muted">
+                Set <code>SUPABASE_URL</code>, <code>SUPABASE_ANON_KEY</code>, and <code>SUPABASE_SERVICE_ROLE</code> in the
+                environment.
+              </p>
+            </div>
+          </Theme>
+        </body>
+      </html>
+    );
+  }
+
+  const staffUser = await getStaffUser();
 
   if (!staffUser) {
     return (

--- a/apps/console/lib/supabase.ts
+++ b/apps/console/lib/supabase.ts
@@ -4,11 +4,28 @@ import { cookies } from 'next/headers';
 
 const requiredEnv = ['SUPABASE_URL', 'SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE'] as const;
 
+export class SupabaseConfigurationError extends Error {
+  missing: string[];
+
+  constructor(missing: string[]) {
+    super(
+      missing.length === 1
+        ? `Missing required environment variable ${missing[0]}`
+        : `Missing required environment variables: ${missing.join(', ')}`
+    );
+    this.name = 'SupabaseConfigurationError';
+    this.missing = missing;
+  }
+}
+
+export function isSupabaseConfigured(): boolean {
+  return requiredEnv.every((key) => Boolean(process.env[key]));
+}
+
 function assertEnv() {
-  for (const key of requiredEnv) {
-    if (!process.env[key]) {
-      throw new Error(`Missing required environment variable ${key}`);
-    }
+  const missing = requiredEnv.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new SupabaseConfigurationError(missing);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated SupabaseConfigurationError helper so the console can detect incomplete environment configuration
- guard authentication helpers and the root layout to return a friendly placeholder instead of crashing when Supabase is missing
- short-circuit the overview page with a neutral card when Supabase is not configured to avoid build-time failures

## Testing
- pnpm -F @torvus/console build

------
https://chatgpt.com/codex/tasks/task_b_68d46f5367a8832dae171ba016d38bc6