### PR TITLE
Refactor console layout for sticky sidebar app shell

### DIFF
--- a/apps/console/app/admin/integrations/page.tsx
+++ b/apps/console/app/admin/integrations/page.tsx
@@ -2,8 +2,6 @@ import Link from 'next/link';
 import { cookies, headers } from 'next/headers';
 import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
-import { AppShell } from '../../../components/AppShell';
-import { Sidebar } from '../../../components/Sidebar';
 import { PageHeader } from '../../../components/PageHeader';
 import { ScrollToSectionButton } from '../../../components/actions/ScrollToSectionButton';
 import { IntegrationsManager, type IntegrationsManagerProps } from '../../../components/admin/IntegrationsManager';
@@ -61,11 +59,9 @@ export default async function AdminIntegrationsPage() {
 
   if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
     );
   }
 
@@ -95,10 +91,10 @@ export default async function AdminIntegrationsPage() {
   } catch (error) {
     console.error('failed to load integrations', error);
     return (
-      <AppShell sidebar={<Sidebar />}>
+      <div className="flex flex-col gap-6">
         <PageHeader
           title="Integrations"
-          subtitle="Manage outbound notifications and event subscriptions."
+          description="Manage outbound notifications and event subscriptions."
           actions={(
             <Flex align="center" gap="3" wrap="wrap">
               <Text size="2" color="gray">
@@ -116,17 +112,15 @@ export default async function AdminIntegrationsPage() {
             </Button>
           </Flex>
         </Callout.Root>
-      </AppShell>
+      </div>
     );
   }
 
   if (integrationsResult.status === 401 || integrationsResult.status === 403 || !integrationsResult.data) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
     );
   }
 
@@ -141,14 +135,14 @@ export default async function AdminIntegrationsPage() {
   );
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         title="Integrations"
-        subtitle="Manage outbound notifications and event subscriptions."
+        description="Manage outbound notifications and event subscriptions."
         actions={headerActions}
       />
 
       <IntegrationsManager initialWebhooks={data.webhooks} initialEvents={data.events} />
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/admin/people/page.tsx
+++ b/apps/console/app/admin/people/page.tsx
@@ -3,8 +3,6 @@ import { Suspense, use } from 'react';
 import { cookies, headers } from 'next/headers';
 import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
-import { AppShell } from '../../../components/AppShell';
-import { Sidebar } from '../../../components/Sidebar';
 import { PageHeader } from '../../../components/PageHeader';
 import { InviteStaffButton } from '../../../components/actions/InviteStaffButton';
 import { SkeletonBlock } from '../../../components/SkeletonBlock';
@@ -147,11 +145,9 @@ export default async function AdminPeoplePage() {
 
   if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
     );
   }
 
@@ -193,15 +189,15 @@ export default async function AdminPeoplePage() {
   })();
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         title="People"
-        subtitle="Security administrators enrolled in Torvus Console."
+        description="Security administrators enrolled in Torvus Console."
         actions={headerActions}
       />
       <Suspense fallback={<PeopleSkeleton />}>
         <PeopleDirectorySection dataPromise={peopleDataPromise} />
       </Suspense>
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/admin/roles/page.tsx
+++ b/apps/console/app/admin/roles/page.tsx
@@ -3,8 +3,6 @@ import { Suspense, use } from 'react';
 import { cookies, headers } from 'next/headers';
 import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
-import { AppShell } from '../../../components/AppShell';
-import { Sidebar } from '../../../components/Sidebar';
 import { PageHeader } from '../../../components/PageHeader';
 import { ScrollToSectionButton } from '../../../components/actions/ScrollToSectionButton';
 import { SkeletonBlock } from '../../../components/SkeletonBlock';
@@ -161,11 +159,9 @@ export default async function AdminRolesPage() {
 
   if (!staffUser || !hasSecurityAdminRole(staffUser.roles)) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice />
-        </Box>
-      </AppShell>
+      <Box py="9">
+        <AccessDeniedNotice />
+      </Box>
     );
   }
 
@@ -207,15 +203,15 @@ export default async function AdminRolesPage() {
   })();
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         title="Roles"
-        subtitle="Manage privileged assignments for staff."
+        description="Manage privileged assignments for staff."
         actions={headerActions}
       />
       <Suspense fallback={<RolesSkeleton />}>
         <RolesDirectorySection dataPromise={rolesDataPromise} />
       </Suspense>
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/audit/page.tsx
+++ b/apps/console/app/audit/page.tsx
@@ -3,8 +3,6 @@ import type { Metadata } from 'next';
 import { Flex, Text } from '@radix-ui/themes';
 import { requireStaff } from '../../lib/auth';
 import { getAnalyticsClient } from '../../lib/analytics';
-import { AppShell } from '../../components/AppShell';
-import { Sidebar } from '../../components/Sidebar';
 import { PageHeader } from '../../components/PageHeader';
 import { RefreshButton } from '../../components/actions/RefreshButton';
 import { AuditClient } from './AuditClient';
@@ -99,11 +97,11 @@ export default async function AuditPage({ searchParams }: { searchParams?: Searc
   });
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         headingId="audit-heading"
         title="Audit trail"
-        subtitle="Time-ordered ledger of privileged console activity."
+        description="Time-ordered ledger of privileged console activity."
         actions={(
           <Flex align="center" gap="3" wrap="wrap">
             <Text size="2" color="gray">
@@ -139,6 +137,6 @@ export default async function AuditPage({ searchParams }: { searchParams?: Searc
           )}
         />
       </section>
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Suspense } from 'react';
-import clsx from 'clsx';
 import '@radix-ui/themes/styles.css';
 import { Theme } from '@radix-ui/themes';
 import '../design/radix-colors.css';
@@ -17,6 +15,7 @@ import { formatBreadcrumb } from '../lib/breadcrumbs';
 import { IdentityPill } from '../components/IdentityPill';
 import { AccessDeniedNotice } from '../components/AccessDeniedNotice';
 import { ReadOnlyBanner } from '../components/ReadOnlyBanner';
+import { Sidebar } from '../components/Sidebar';
 
 export const metadata: Metadata = {
   title: 'Torvus Console',
@@ -140,9 +139,14 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     }
   }
 
+  const sidebarGroups = navGroups.map((group) => ({
+    title: group.group,
+    items: group.items
+  }));
+
   return (
     <html lang="en" data-theme="torvus-staff">
-      <body data-correlation={correlationId} className="layout-shell">
+      <body data-correlation={correlationId}>
         <Theme
           appearance="dark"
           radius="large"
@@ -151,50 +155,33 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
           grayColor="slate"
           panelBackground="translucent"
         >
-          <aside className="sidebar" aria-label="Primary">
-            <div className="sidebar__brand">
-              <span className="brand-mark" aria-hidden>
-                ⚡
-              </span>
-              <span className="brand-text">Torvus Console</span>
-            </div>
-            <nav>
-              {navGroups.map((group) => (
-                <div key={group.group} className="nav-group">
-                  <div className="nav-group__label">{group.group}</div>
-                  <ul>
-                    {group.items.map((item) => (
-                      <li key={item.href}>
-                        <Link
-                          href={item.href}
-                          className={clsx('nav-link', {
-                            active:
-                              pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href))
-                          })}
-                        >
-                          {item.label}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </nav>
-            <footer>
-              <span className="staff-name">{staffUser.displayName}</span>
-              <span className="staff-email">{staffUser.email}</span>
-            </footer>
-          </aside>
-          <div className="content">
-            {readOnlyEnabled ? <ReadOnlyBanner message={readOnlyMessage} /> : null}
-            <header className="topbar">
-              <div className="breadcrumbs">{formatBreadcrumb(pathname)}</div>
-              <div className="topbar__meta" data-nonce={nonce}>
-                <IdentityPill displayName={staffUser.displayName} email={staffUser.email} roles={staffUser.roles} />
+          <div className="grid min-h-screen grid-cols-[280px_minmax(0,1fr)]">
+            <aside
+              aria-label="Primary"
+              className="border-r border-slate-200 bg-slate-50/40 dark:border-slate-800 dark:bg-slate-950/20"
+            >
+              <div className="sticky top-0 h-screen overflow-y-auto">
+                <Sidebar groups={sidebarGroups} displayName={staffUser.displayName} email={staffUser.email} />
               </div>
-            </header>
-            <main className="main" data-testid="main-content">
-              <Suspense fallback={<div className="loading" data-testid="loading" />}>{children}</Suspense>
+            </aside>
+            <main className="min-h-screen overflow-y-auto" data-testid="main-content">
+              <div className="mx-auto flex max-w-[1200px] flex-col gap-6 px-6 py-8">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-300">
+                    {formatBreadcrumb(pathname)}
+                  </div>
+                  <div data-nonce={nonce} className="flex w-full justify-end sm:w-auto">
+                    <IdentityPill
+                      displayName={staffUser.displayName}
+                      email={staffUser.email}
+                      roles={staffUser.roles}
+                      className="sm:w-auto sm:max-w-none"
+                    />
+                  </div>
+                </div>
+                {readOnlyEnabled ? <ReadOnlyBanner message={readOnlyMessage} /> : null}
+                <Suspense fallback={<div className="loading" data-testid="loading" />}>{children}</Suspense>
+              </div>
             </main>
           </div>
         </Theme>

--- a/apps/console/app/overview/page.tsx
+++ b/apps/console/app/overview/page.tsx
@@ -16,8 +16,6 @@ import { countAlerts } from '../../lib/data/alerts';
 import { countInvestigations } from '../../lib/data/investigations';
 import { isSupabaseConfigured } from '../../lib/supabase';
 import { logAudit } from '../../server/audit';
-import { AppShell } from '../../components/AppShell';
-import { Sidebar } from '../../components/Sidebar';
 import { PageHeader } from '../../components/PageHeader';
 
 const DEFAULT_STATS = {
@@ -148,14 +146,14 @@ export default async function OverviewPage() {
 
   if (!supabaseConfigured) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <PageHeader title="Overview" subtitle="Operations & security at a glance" />
+      <div className="flex flex-col gap-6">
+        <PageHeader title="Overview" description="Operations & security at a glance" />
         <Card size="3">
           <Text size="3" color="gray">
             Supabase configuration is required to display overview metrics.
           </Text>
         </Card>
-      </AppShell>
+      </div>
     );
   }
 
@@ -191,10 +189,10 @@ export default async function OverviewPage() {
   });
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         title="Overview"
-        subtitle="Operations & security at a glance"
+        description="Operations & security at a glance"
         actions={(
           <Text size="2" color="gray">
             Signed in as {staffUser.displayName}
@@ -376,6 +374,6 @@ export default async function OverviewPage() {
           </Flex>
         </Card>
       </Grid>
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/profile/page.tsx
+++ b/apps/console/app/profile/page.tsx
@@ -7,8 +7,6 @@ import { createSupabaseServiceRoleClient } from '../../lib/supabase';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
 import { PersonalAccessTokensPanel } from './PersonalAccessTokensPanel';
 import { enforceNotReadOnly, isReadOnlyError } from '../../server/guard';
-import { AppShell } from '../../components/AppShell';
-import { Sidebar } from '../../components/Sidebar';
 import { PageHeader } from '../../components/PageHeader';
 
 async function saveProfileAction(
@@ -73,19 +71,17 @@ export default async function ProfilePage() {
 
   if (!staffUser) {
     return (
-      <AppShell sidebar={<Sidebar />}>
-        <Box py="9">
-          <AccessDeniedNotice variant="card" />
-        </Box>
-      </AppShell>
+      <Box py="9">
+        <AccessDeniedNotice variant="card" />
+      </Box>
     );
   }
 
   return (
-    <AppShell sidebar={<Sidebar />}>
+    <div className="flex flex-col gap-6">
       <PageHeader
         title="Profile"
-        subtitle="Manage how your identity appears across audit trails and console workflows."
+        description="Manage how your identity appears across audit trails and console workflows."
         actions={(
           <Flex align="center" gap="3" wrap="wrap">
             <Text size="2" color="gray">
@@ -110,6 +106,6 @@ export default async function ProfilePage() {
         </Box>
         <PersonalAccessTokensPanel />
       </Flex>
-    </AppShell>
+    </div>
   );
 }

--- a/apps/console/app/tokens/TokensPageContent.tsx
+++ b/apps/console/app/tokens/TokensPageContent.tsx
@@ -20,7 +20,7 @@ export function TokensPageContent({ displayName, email }: TokensPageContentProps
     <>
       <PageHeader
         title="Personal access tokens"
-        subtitle="Generate API secrets tied to your staff identity."
+        description="Generate API secrets tied to your staff identity."
         actions={(
           <Flex align="center" gap="3" wrap="wrap">
             <Text size="2" color="gray">

--- a/apps/console/app/tokens/page.tsx
+++ b/apps/console/app/tokens/page.tsx
@@ -1,5 +1,3 @@
-import { AppShell } from '../../components/AppShell';
-import { Sidebar } from '../../components/Sidebar';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
 import { getStaffUser } from '../../lib/auth';
 import { TokensPageContent } from './TokensPageContent';
@@ -8,16 +6,8 @@ export default async function TokensPage() {
   const staffUser = await getStaffUser();
 
   if (!staffUser) {
-    return (
-      <AppShell sidebar={<Sidebar />}>
-        <AccessDeniedNotice />
-      </AppShell>
-    );
+    return <AccessDeniedNotice />;
   }
 
-  return (
-    <AppShell sidebar={<Sidebar />}>
-      <TokensPageContent displayName={staffUser.displayName} email={staffUser.email} />
-    </AppShell>
-  );
+  return <TokensPageContent displayName={staffUser.displayName} email={staffUser.email} />;
 }

--- a/apps/console/components/PageHeader.tsx
+++ b/apps/console/components/PageHeader.tsx
@@ -5,12 +5,12 @@ import { Box, Flex, Heading, Separator, Text } from '@radix-ui/themes';
 
 export type PageHeaderProps = {
   title: string;
-  subtitle?: string;
+  description?: string;
   actions?: ReactNode;
   headingId?: string;
 };
 
-export function PageHeader({ title, subtitle, actions, headingId }: PageHeaderProps) {
+export function PageHeader({ title, description, actions, headingId }: PageHeaderProps) {
   return (
     <Box mb="5">
       <Flex
@@ -24,9 +24,9 @@ export function PageHeader({ title, subtitle, actions, headingId }: PageHeaderPr
           <Heading as="h1" size="6" id={headingId}>
             {title}
           </Heading>
-          {subtitle ? (
+          {description ? (
             <Text size="2" color="gray" mt="2">
-              {subtitle}
+              {description}
             </Text>
           ) : null}
         </Box>


### PR DESCRIPTION
## Summary
- rebuild the console root layout with a two-column grid, sticky sidebar, and centered scrolling content
- replace the old hard-coded sidebar with a reusable component that renders navigation groups and user identity
- refresh the PageHeader API and update console pages to use the shared shell without absolute positioning

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68d4778a3dbc832d80b71ea2209104c7