### PR TITLE
feat: unify navigation layout and routing

### DIFF
--- a/apps/console/app/account/profile/page.tsx
+++ b/apps/console/app/account/profile/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../../profile/page';
+export { default } from '../../profile/page';

--- a/apps/console/app/admin/break-glass/page.tsx
+++ b/apps/console/app/admin/break-glass/page.tsx
@@ -1,4 +1,5 @@
 import { AccessDeniedNotice } from '../../../components/AccessDeniedNotice';
+import { PageHeader } from '../../../components/PageHeader';
 import {
   BreakGlassDashboard,
   type RoleOption,
@@ -69,12 +70,18 @@ export default async function BreakGlassAdminPage() {
     .filter((role) => role.name.length > 0);
 
   return (
-    <BreakGlassDashboard
-      staff={staff}
-      roles={roles}
-      canRequest={canRequest}
-      canApprove={canApprove}
-      currentUserId={staffUser.id}
-    />
+    <div className="flex flex-col gap-6 py-6">
+      <PageHeader
+        title="Break glass"
+        description="Emergency elevated access workflows managed by security administrators."
+      />
+      <BreakGlassDashboard
+        staff={staff}
+        roles={roles}
+        canRequest={canRequest}
+        canApprove={canApprove}
+        currentUserId={staffUser.id}
+      />
+    </div>
   );
 }

--- a/apps/console/app/admin/staff/page.tsx
+++ b/apps/console/app/admin/staff/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../../staff/page';
+export { default } from '../../staff/page';

--- a/apps/console/app/alerts/page.tsx
+++ b/apps/console/app/alerts/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Suspense } from 'react';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+import { PageHeader } from '../../components/PageHeader';
 import { getStaffUser } from '../../lib/auth';
 import { listAlerts } from '../../lib/data/alerts';
 
@@ -169,6 +170,7 @@ export default async function AlertsPage() {
 
   return (
     <div className="flex flex-col gap-8 py-6">
+      <PageHeader title="Alerts" description="Monitor incidents raised by Torvus detection sources." />
       <Suspense fallback={<AlertsSkeleton />}>
         <AlertsListSection />
       </Suspense>

--- a/apps/console/app/audit-events/page.tsx
+++ b/apps/console/app/audit-events/page.tsx
@@ -2,6 +2,7 @@ import { headers } from 'next/headers';
 import { requireStaff } from '../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../lib/supabase';
 import { getAnalyticsClient } from '../../lib/analytics';
+import { PageHeader } from '../../components/PageHeader';
 import { exportAuditCsv, exportAuditJson } from './actions';
 import { FilterSchema, FilterValues, AuditEventRow } from './shared';
 
@@ -99,12 +100,15 @@ export default async function AuditEventsPage({
   }
 
   return (
-    <div className="page">
+    <div className="page flex flex-col gap-6">
+      <PageHeader
+        title="Audit events"
+        description="Detailed activity log for compliance-ready evidence."
+        headingId="audit-heading"
+        actions={<span className="tag subtle">Evidence ready</span>}
+      />
+
       <section className="panel" aria-labelledby="audit-heading">
-        <div className="panel__header">
-          <h1 id="audit-heading">Audit events</h1>
-          <span className="tag subtle">Evidence ready</span>
-        </div>
         <form method="get" className="filters" data-testid="audit-filter-form">
           <label>
             Actor

--- a/apps/console/app/investigations/page.tsx
+++ b/apps/console/app/investigations/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Suspense } from 'react';
 import clsx from 'clsx';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+import { PageHeader } from '../../components/PageHeader';
 import { getStaffUser } from '../../lib/auth';
 import { INVESTIGATION_SEVERITIES, INVESTIGATION_STATUSES } from '../../lib/investigations/constants';
 import { listInvestigations, type InvestigationListItem } from '../../lib/data/investigations';
@@ -373,13 +374,11 @@ export default async function InvestigationsPage({ searchParams }: { searchParam
 
   return (
     <div className="flex flex-col gap-6 py-6">
-      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
-        <div>
-          <h1 className="text-3xl font-semibold text-slate-100">Investigations</h1>
-          <p className="text-sm text-slate-400">Lightweight case tracking for Torvus responders.</p>
-        </div>
-        <NewInvestigationDialog canManage={canManage} />
-      </div>
+      <PageHeader
+        title="Investigations"
+        description="Lightweight case tracking for Torvus responders."
+        actions={<NewInvestigationDialog canManage={canManage} />}
+      />
 
       <FiltersForm filters={filters} />
 

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -11,7 +11,6 @@ import '../styles/globals.css';
 import { getStaffUser } from '../lib/auth';
 import { buildNavItems, getAnalyticsClient } from '../lib/analytics';
 import { isSupabaseConfigured } from '../lib/supabase';
-import { formatBreadcrumb } from '../lib/breadcrumbs';
 import { IdentityPill } from '../components/IdentityPill';
 import { AccessDeniedNotice } from '../components/AccessDeniedNotice';
 import { ReadOnlyBanner } from '../components/ReadOnlyBanner';
@@ -166,18 +165,13 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             </aside>
             <main className="min-h-screen overflow-y-auto" data-testid="main-content">
               <div className="mx-auto flex max-w-[1200px] flex-col gap-6 px-6 py-8">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div className="text-sm font-medium text-slate-500 dark:text-slate-300">
-                    {formatBreadcrumb(pathname)}
-                  </div>
-                  <div data-nonce={nonce} className="flex w-full justify-end sm:w-auto">
-                    <IdentityPill
-                      displayName={staffUser.displayName}
-                      email={staffUser.email}
-                      roles={staffUser.roles}
-                      className="sm:w-auto sm:max-w-none"
-                    />
-                  </div>
+                <div data-nonce={nonce} className="flex justify-end">
+                  <IdentityPill
+                    displayName={staffUser.displayName}
+                    email={staffUser.email}
+                    roles={staffUser.roles}
+                    className="sm:w-auto sm:max-w-none"
+                  />
                 </div>
                 {readOnlyEnabled ? <ReadOnlyBanner message={readOnlyMessage} /> : null}
                 <Suspense fallback={<div className="loading" data-testid="loading" />}>{children}</Suspense>

--- a/apps/console/app/releases/page.tsx
+++ b/apps/console/app/releases/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+import { PageHeader } from '../../components/PageHeader';
 import { callReleasesApi } from './api-client';
 
 type StaffSummary = {
@@ -50,16 +51,19 @@ export default async function ReleasesPage() {
   const { requests } = data;
 
   return (
-    <div className="page space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-white">Release requests</h1>
-        <Link
-          href="/releases/new"
-          className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-emerald-400"
-        >
-          New release
-        </Link>
-      </div>
+    <div className="page flex flex-col gap-6">
+      <PageHeader
+        title="Release requests"
+        description="Dual-control automation for production changes."
+        actions={
+          <Link
+            href="/releases/new"
+            className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-emerald-400"
+          >
+            New release
+          </Link>
+        }
+      />
 
       <div className="panel" aria-labelledby="release-requests-heading">
         <div className="panel__header">

--- a/apps/console/app/security/events/page.tsx
+++ b/apps/console/app/security/events/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../../audit/page';
+export { default } from '../../audit/page';

--- a/apps/console/app/security/policies/page.tsx
+++ b/apps/console/app/security/policies/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import { Card, Flex, Text } from '@radix-ui/themes';
+import { PageHeader } from '../../../components/PageHeader';
+
+export const metadata: Metadata = {
+  title: 'Security policies — Torvus Console'
+};
+
+export default function SecurityPoliciesPage() {
+  return (
+    <div className="flex flex-col gap-6 py-6">
+      <PageHeader title="Policies" description="Define guardrails for Torvus security enforcement." />
+      <Card variant="surface" className="border border-slate-800/60 bg-slate-950/40">
+        <Flex direction="column" gap="2">
+          <Text weight="medium">Coming soon</Text>
+          <Text size="2" color="gray">
+            We are working on automated policy management to centralise controls.
+          </Text>
+        </Flex>
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/app/staff/page.tsx
+++ b/apps/console/app/staff/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { AccessDeniedNotice } from '../../components/AccessDeniedNotice';
+import { PageHeader } from '../../components/PageHeader';
 import { StaffTable } from '../../components/StaffTable';
 import { getStaffUser } from '../../lib/auth';
 import { getAllStaffWithRoles, getCurrentStaffWithRoles } from '../../lib/data/staff';
@@ -49,6 +50,7 @@ export default async function StaffPage({ searchParams }: StaffPageProps) {
 
     return (
       <div className="flex flex-col gap-8 py-6">
+        <PageHeader title="Staff directory" description="Manage Torvus operators and assigned roles." />
         <StaffTable staff={staff} query={query} page={page} pageSize={PAGE_SIZE} totalCount={count} />
       </div>
     );

--- a/apps/console/components/Sidebar.tsx
+++ b/apps/console/components/Sidebar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
 import { Box, Flex, Text } from '@radix-ui/themes';
 
 export type SidebarNavItem = {
@@ -29,13 +31,30 @@ function NavLink({ href, label }: SidebarNavItem) {
   const isActive = isExactMatch || isNestedMatch;
 
   return (
-    <Box
+    <Text
       asChild
-      data-active={isActive ? 'true' : undefined}
-      className="block rounded-md px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-200/60 hover:text-slate-900 data-[active=true]:bg-slate-200 data-[active=true]:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-700/50 dark:hover:text-slate-100 dark:data-[active=true]:bg-slate-700/70 dark:data-[active=true]:text-slate-50"
+      size="2"
+      weight={isActive ? 'medium' : 'regular'}
+      color={isActive ? 'iris' : 'gray'}
+      className={clsx(
+        'block rounded-r-md border-l-2 px-3 py-2 transition-colors',
+        'border-transparent hover:border-slate-400 hover:bg-slate-200/60 dark:hover:border-slate-600 dark:hover:bg-slate-700/40',
+        !isActive && 'hover:text-slate-900 dark:hover:text-slate-100'
+      )}
+      style={
+        isActive
+          ? ({
+              borderLeftColor: 'var(--accent-9)',
+              backgroundColor: 'var(--accent-4)',
+              color: 'var(--accent-12)'
+            } satisfies CSSProperties)
+          : undefined
+      }
     >
-      <Link href={href}>{label}</Link>
-    </Box>
+      <NextLink href={href} aria-current={isActive ? 'page' : undefined}>
+        {label}
+      </NextLink>
+    </Text>
   );
 }
 

--- a/apps/console/lib/analytics.ts
+++ b/apps/console/lib/analytics.ts
@@ -21,11 +21,17 @@ type NavItem = {
 const NAV_ITEMS: NavItem[] = [
   { href: '/overview', label: 'Overview', permission: 'metrics.view', group: 'Operations' },
   { href: '/alerts', label: 'Alerts', group: 'Operations' },
-  { href: '/investigations', label: 'Investigations', permission: 'investigations.view', group: 'Operations' },
+  {
+    href: '/investigations',
+    label: 'Investigations',
+    permission: 'investigations.view',
+    group: 'Operations'
+  },
   { href: '/releases', label: 'Releases', permission: 'releases.simulate', group: 'Operations' },
-  { href: '/audit', label: 'Audit trail', permission: 'audit.read', group: 'Security' },
+  { href: '/security/events', label: 'Security events', permission: 'audit.read', group: 'Security' },
+  { href: '/security/policies', label: 'Policies', group: 'Security' },
   { href: '/admin/break-glass', label: 'Break Glass', permission: 'investigations.manage', group: 'Security' },
-  { href: '/profile', label: 'Profile', group: 'Account' }
+  { href: '/account/profile', label: 'Profile', group: 'Account' }
 ];
 
 const NAV_GROUP_ORDER: Array<NonNullable<NavItem['group']>> = ['Operations', 'Security', 'Account', 'Admin'];


### PR DESCRIPTION
## Summary
- refine the sidebar to group primary routes, highlight the active entry, and keep section ordering consistent
- add PageHeader usage to key pages plus a security policies placeholder for a uniform main column header
- expose account/profile, admin/staff, and security/events routes via re-exports so navigation targets resolve

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68d4805806ac832db5635ac7d434e943