### PR TITLE
Unify identity detection across middleware and server code

### DIFF
--- a/apps/console/app/(lib)/authz.ts
+++ b/apps/console/app/(lib)/authz.ts
@@ -1,4 +1,3 @@
-import { cache } from 'react';
 import {
   SupabaseConfigurationError,
   createSupabaseServiceRoleClient,
@@ -88,7 +87,7 @@ function noteMissingSupabaseConfig(error: unknown): boolean {
   return true;
 }
 
-export const loadAuthz = cache(async function loadAuthz(): Promise<AuthzResult> {
+export async function loadAuthz(): Promise<AuthzResult> {
   const sessionUser = await getSessionUser();
   const sessionEmail = normaliseStaffEmail(sessionUser?.email ?? null);
 
@@ -202,7 +201,7 @@ export const loadAuthz = cache(async function loadAuthz(): Promise<AuthzResult> 
     passkeyEnrolled,
     allowed
   };
-});
+}
 
 type RoleCheck = {
   anyOf?: string[];

--- a/apps/console/app/access-denied/page.tsx
+++ b/apps/console/app/access-denied/page.tsx
@@ -11,6 +11,7 @@ export default function AccessDeniedPage() {
     ?.split(';')
     .map((entry) => entry.trim())
     .find((entry) => entry.length > 0);
+  const formattedReason = reason === 'missing_email' ? 'missing email' : reason;
 
-  return <AccessDeniedNotice debugInfo={{ requestId, reason }} />;
+  return <AccessDeniedNotice debugInfo={{ requestId, reason: formattedReason }} />;
 }

--- a/apps/console/app/admin/integrations/intake/page.tsx
+++ b/apps/console/app/admin/integrations/intake/page.tsx
@@ -1,6 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import { IntakeIntegrationsManager, type IntakeIntegrationsManagerProps } from '../../../../components/admin/IntakeIntegrationsManager';
-import { getStaffUser } from '../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getStaffUser } from '../../../../lib/auth';
 import { loadAuthz, authorizeRoles } from '../../../(lib)/authz';
 import { DeniedPanel } from '../../../(lib)/denied-panel';
 
@@ -26,7 +26,7 @@ async function fetchIntakeData(baseUrl: string, emailHeader: string | null): Pro
     headersMap.set('cookie', cookieHeader);
   }
   if (emailHeader) {
-    headersMap.set('x-authenticated-staff-email', emailHeader);
+    headersMap.set('x-torvus-console-email', emailHeader);
   }
 
   const response = await fetch(`${baseUrl}/api/admin/integrations/intake`, {
@@ -85,10 +85,8 @@ export default async function IntakeIntegrationsPage() {
 
   const baseUrl = resolveBaseUrl();
   const headerBag = headers();
-  const headerEmail =
-    headerBag.get('x-authenticated-staff-email')
-    ?? headerBag.get('x-session-user-email')
-    ?? staffUser.email;
+  const identity = getIdentityFromRequestHeaders(headerBag);
+  const headerEmail = identity.email ?? staffUser.email;
 
   const { status, data } = await fetchIntakeData(baseUrl, headerEmail);
 

--- a/apps/console/app/admin/integrations/page.tsx
+++ b/apps/console/app/admin/integrations/page.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Callout, Flex, Text } from '@radix-ui/themes';
 import { PageHeader } from '../../../components/PageHeader';
 import { ScrollToSectionButton } from '../../../components/actions/ScrollToSectionButton';
 import { IntegrationsManager, type IntegrationsManagerProps } from '../../../components/admin/IntegrationsManager';
-import { getStaffUser } from '../../../lib/auth';
+import { getIdentityFromRequestHeaders, getStaffUser } from '../../../lib/auth';
 import { loadAuthz, authorizeRoles } from '../../(lib)/authz';
 import { DeniedPanel } from '../../(lib)/denied-panel';
 
@@ -31,7 +31,7 @@ async function fetchIntegrations(baseUrl: string, emailHeader: string | null): P
     headersMap.set('cookie', cookieHeader);
   }
   if (emailHeader) {
-    headersMap.set('x-authenticated-staff-email', emailHeader);
+    headersMap.set('x-torvus-console-email', emailHeader);
   }
 
   const response = await fetch(`${baseUrl}/api/admin/integrations`, {
@@ -99,10 +99,8 @@ export default async function AdminIntegrationsPage() {
     baseUrl = process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
   }
 
-  const headerEmail =
-    headerBag.get('x-authenticated-staff-email')
-    ?? headerBag.get('x-session-user-email')
-    ?? staffUser.email;
+  const identity = getIdentityFromRequestHeaders(headerBag);
+  const headerEmail = identity.email ?? staffUser.email;
 
   let integrationsResult: FetchResult;
 

--- a/apps/console/app/admin/people/page.tsx
+++ b/apps/console/app/admin/people/page.tsx
@@ -7,7 +7,7 @@ import { InviteStaffButton } from '../../../components/actions/InviteStaffButton
 import { SkeletonBlock } from '../../../components/SkeletonBlock';
 import { EmptyState } from '../../../components/EmptyState';
 import { PeopleTable, type AdminPersonRecord } from '../../../components/admin/PeopleTable';
-import { getStaffUser } from '../../../lib/auth';
+import { getIdentityFromRequestHeaders, getStaffUser } from '../../../lib/auth';
 import { loadAuthz, authorizeRoles } from '../../(lib)/authz';
 import { DeniedPanel } from '../../(lib)/denied-panel';
 
@@ -33,7 +33,7 @@ async function fetchPeople(baseUrl: string, emailHeader: string | null): Promise
     headersMap.set('cookie', cookieHeader);
   }
   if (emailHeader) {
-    headersMap.set('x-authenticated-staff-email', emailHeader);
+    headersMap.set('x-torvus-console-email', emailHeader);
   }
 
   const response = await fetch(`${baseUrl}/api/admin/people`, {
@@ -185,10 +185,8 @@ export default async function AdminPeoplePage() {
     baseUrl = process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
   }
 
-  const headerEmail =
-    headerBag.get('x-authenticated-staff-email')
-    ?? headerBag.get('x-session-user-email')
-    ?? staffUser.email;
+  const identity = getIdentityFromRequestHeaders(headerBag);
+  const headerEmail = identity.email ?? staffUser.email;
 
   const headerActions = (
     <Flex align="center" gap="3" wrap="wrap">

--- a/apps/console/app/admin/roles/page.tsx
+++ b/apps/console/app/admin/roles/page.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from '../../../components/PageHeader';
 import { ScrollToSectionButton } from '../../../components/actions/ScrollToSectionButton';
 import { SkeletonBlock } from '../../../components/SkeletonBlock';
 import { RoleManager, type RoleMemberRecord } from '../../../components/admin/RoleManager';
-import { getStaffUser } from '../../../lib/auth';
+import { getIdentityFromRequestHeaders, getStaffUser } from '../../../lib/auth';
 import { loadAuthz, authorizeRoles } from '../../(lib)/authz';
 import { DeniedPanel } from '../../(lib)/denied-panel';
 
@@ -43,7 +43,7 @@ async function fetchRoles(baseUrl: string, emailHeader: string | null): Promise<
     headersMap.set('cookie', cookieHeader);
   }
   if (emailHeader) {
-    headersMap.set('x-authenticated-staff-email', emailHeader);
+    headersMap.set('x-torvus-console-email', emailHeader);
   }
 
   const response = await fetch(`${baseUrl}/api/admin/roles`, {
@@ -199,10 +199,8 @@ export default async function AdminRolesPage() {
     baseUrl = process.env.NEXT_PUBLIC_CONSOLE_URL ?? 'http://localhost:3000';
   }
 
-  const headerEmail =
-    headerBag.get('x-authenticated-staff-email')
-    ?? headerBag.get('x-session-user-email')
-    ?? staffUser.email;
+  const identity = getIdentityFromRequestHeaders(headerBag);
+  const headerEmail = identity.email ?? staffUser.email;
 
   const headerActions = (
     <Flex align="center" gap="3" wrap="wrap">

--- a/apps/console/app/api/admin/integrations/_helpers.ts
+++ b/apps/console/app/api/admin/integrations/_helpers.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { getRequesterEmail, getUserRolesByEmail } from '../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
 
 export type AdminContext = {
@@ -11,7 +11,7 @@ export type AdminContext = {
 export async function requireSecurityAdmin(
   request: Request
 ): Promise<{ ok: true; context: AdminContext } | { ok: false; response: Response }> {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return { ok: false, response: new Response('unauthorized', { status: 401 }) };
   }

--- a/apps/console/app/api/admin/people/route.ts
+++ b/apps/console/app/api/admin/people/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getRequesterEmail, getUserRolesByEmail } from '../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }

--- a/apps/console/app/api/admin/roles/assign/route.ts
+++ b/apps/console/app/api/admin/roles/assign/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getRequesterEmail, getUserRolesByEmail } from '../../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
 import { logAudit } from '../../../../../server/audit';
 
@@ -13,7 +13,7 @@ type StaffRoleRow = {
 };
 
 export async function POST(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }

--- a/apps/console/app/api/admin/roles/route.ts
+++ b/apps/console/app/api/admin/roles/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getRequesterEmail, getUserRolesByEmail } from '../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -29,7 +29,7 @@ type MemberRow = {
 };
 
 export async function GET(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }

--- a/apps/console/app/api/admin/roles/unassign/route.ts
+++ b/apps/console/app/api/admin/roles/unassign/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getRequesterEmail, getUserRolesByEmail } from '../../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
 import { logAudit } from '../../../../../server/audit';
 
@@ -13,7 +13,7 @@ type StaffRoleRow = {
 };
 
 export async function POST(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }

--- a/apps/console/app/api/admin/settings/read-only/route.ts
+++ b/apps/console/app/api/admin/settings/read-only/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getRequesterEmail, getUserRolesByEmail, getStaffUserByEmail } from '../../../../../lib/auth';
+import { getIdentityFromRequestHeaders, getUserRolesByEmail, getStaffUserByEmail } from '../../../../../lib/auth';
 import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
 import { getReadOnly, setReadOnly } from '../../../../../server/settings';
 
@@ -10,7 +10,7 @@ function hasSecurityAdminRole(roles: string[]): boolean {
 }
 
 export async function GET(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return new Response('unauthorized', { status: 401 });
   }

--- a/apps/console/app/api/investigations/utils.ts
+++ b/apps/console/app/api/investigations/utils.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
 import {
-  getRequesterEmail,
+  getIdentityFromRequestHeaders,
   getStaffUserByEmail,
   getUserRolesByEmail,
   type StaffUserRecord
@@ -26,7 +26,7 @@ const VIEW_ROLES = new Set(['security_admin', 'investigator', 'auditor']);
 const MANAGE_ROLES = new Set(['security_admin', 'investigator']);
 
 export async function resolveViewer(request: Request): Promise<ViewerResolution> {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return { type: 'error', response: new Response('unauthorized', { status: 401 }) };
   }

--- a/apps/console/app/api/releases/utils.ts
+++ b/apps/console/app/api/releases/utils.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import {
-  getRequesterEmail,
+  getIdentityFromRequestHeaders,
   getStaffUserByEmail,
   getUserRolesByEmail,
   type StaffUserRecord
@@ -23,7 +23,7 @@ type ViewerError = {
 export type ViewerResolution = ViewerOk | ViewerError;
 
 export async function resolveViewer(request: Request): Promise<ViewerResolution> {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return { type: 'error', response: new Response('unauthorized', { status: 401 }) };
   }

--- a/apps/console/app/releases/api-client.ts
+++ b/apps/console/app/releases/api-client.ts
@@ -1,4 +1,5 @@
 import { cookies, headers } from 'next/headers';
+import { getIdentityFromRequestHeaders } from '../../lib/auth';
 
 type ApiCallOptions = Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
 
@@ -21,9 +22,8 @@ function resolveBaseUrl(): { baseUrl: string; emailHeader: string | null; cookie
     baseUrl = `${protocol}://${host}`;
   }
 
-  const headerEmail =
-    headerBag.get('x-authenticated-staff-email')
-    ?? headerBag.get('x-session-user-email');
+  const identity = getIdentityFromRequestHeaders(headerBag);
+  const headerEmail = identity.email ?? null;
 
   const cookieStore = cookies();
   const cookieHeader = cookieStore
@@ -42,7 +42,7 @@ export async function callReleasesApi<T>(path: string, options: ApiCallOptions =
     headersMap.set('cookie', cookieHeader);
   }
   if (emailHeader) {
-    headersMap.set('x-authenticated-staff-email', emailHeader);
+    headersMap.set('x-torvus-console-email', emailHeader);
   }
   headersMap.set('accept', 'application/json');
 

--- a/apps/console/components/AccessDeniedNotice.tsx
+++ b/apps/console/components/AccessDeniedNotice.tsx
@@ -12,13 +12,14 @@ export type AccessDeniedNoticeProps = {
 export function AccessDeniedNotice({ variant = 'full', className, debugInfo }: AccessDeniedNoticeProps) {
   const isDebugEnv = process.env.NODE_ENV !== 'production';
   const debugLines: string[] = [];
+  const reasonMessage = debugInfo?.reason?.trim() ? debugInfo.reason.trim() : null;
 
   if (isDebugEnv && debugInfo) {
     if (debugInfo.requestId) {
       debugLines.push(`request ${debugInfo.requestId}`);
     }
-    if (debugInfo.reason) {
-      debugLines.push(debugInfo.reason);
+    if (reasonMessage) {
+      debugLines.push(reasonMessage);
     }
   }
 
@@ -39,6 +40,11 @@ export function AccessDeniedNotice({ variant = 'full', className, debugInfo }: A
           <Text size="2" color="gray" align="center">
             Torvus Console is restricted to enrolled staff. Contact Security Operations.
           </Text>
+          {reasonMessage ? (
+            <Text size="2" color="gray" align="center" data-testid="access-denied-reason">
+              Reason: {reasonMessage}
+            </Text>
+          ) : null}
           {debugMessage ? (
             <Text size="1" color="gray" align="center" data-testid="access-denied-debug">
               {debugMessage}
@@ -53,6 +59,11 @@ export function AccessDeniedNotice({ variant = 'full', className, debugInfo }: A
     <main className={clsx('unauthorised', className)}>
       <h1>Access denied</h1>
       <p>Torvus Console is restricted to enrolled staff. Contact Security Operations.</p>
+      {reasonMessage ? (
+        <p className="access-denied-reason" data-testid="access-denied-reason">
+          Reason: {reasonMessage}
+        </p>
+      ) : null}
       {debugMessage ? (
         <p className="access-denied-debug" data-testid="access-denied-debug">
           {debugMessage}

--- a/apps/console/lib/auth.ts
+++ b/apps/console/lib/auth.ts
@@ -204,6 +204,17 @@ export async function getSessionUser(): Promise<SessionUser | null> {
     };
   }
 
+  if (allowCfFallback) {
+    const identity = getIdentityFromRequestHeaders();
+    if (identity.email) {
+      return {
+        id: null,
+        email: identity.email,
+        user_metadata: { identitySource: identity.source }
+      };
+    }
+  }
+
   return null;
 }
 

--- a/apps/console/lib/self.ts
+++ b/apps/console/lib/self.ts
@@ -1,4 +1,4 @@
-import { getRequesterEmail } from './auth';
+import { getIdentityFromRequestHeaders } from './auth';
 import { createSupabaseServiceRoleClient } from './supabase';
 import { evaluateAccessGate } from './authz/gate';
 
@@ -10,7 +10,7 @@ export type SelfProfile = {
 };
 
 export async function getSelf(request: Request): Promise<SelfProfile | null> {
-  const email = getRequesterEmail(request);
+  const { email } = getIdentityFromRequestHeaders(request.headers);
   if (!email) {
     return null;
   }

--- a/apps/console/server/audit.ts
+++ b/apps/console/server/audit.ts
@@ -2,7 +2,7 @@ import { headers as nextHeaders } from 'next/headers';
 import type { NextRequest } from 'next/server';
 import { createSupabaseServiceRoleClient } from '../lib/supabase';
 import {
-  getRequesterEmail,
+  getIdentityFromRequestHeaders,
   getSessionUser,
   getStaffUserByEmail,
   getUserRolesByEmail,
@@ -102,8 +102,8 @@ async function resolveActor(
 
   if (!actorEmail) {
     try {
-      const request = new Request('https://internal.local/audit', { headers });
-      actorEmail = getRequesterEmail(request);
+      const identity = getIdentityFromRequestHeaders(headers);
+      actorEmail = identity.email ?? null;
     } catch (error) {
       console.warn('[audit] failed to resolve requester email', error);
     }


### PR DESCRIPTION
## Summary
- Add a single getIdentityFromRequestHeaders helper to centralize staff identity parsing and remove request-scoped memoization
- Update middleware, server pages, and API handlers to rely on the shared identity helper, forward roles headers, and expose an /api/self diagnostics route
- Surface access-denied reasons in the UI to simplify debugging unexpected gate failures

## Testing
- pnpm --filter @torvus/console lint
- pnpm --filter @torvus/console test

------
https://chatgpt.com/codex/tasks/task_b_68d4cb9e9278832d99da556bfe861d99