### PR TITLE
Fix analytics crypto usage for Next build

### DIFF
--- a/apps/console/lib/analytics.ts
+++ b/apps/console/lib/analytics.ts
@@ -1,4 +1,5 @@
-import { randomUUID, createHash } from 'node:crypto';
+import 'server-only';
+import { createHash, randomUUID as nodeRandomUUID } from 'crypto';
 import type { PermissionKey } from './rbac';
 
 export type AnalyticsEventKey =
@@ -49,7 +50,9 @@ class AnalyticsClient {
         env: process.env.NODE_ENV ?? 'development',
         ...payload
       },
-      uuid: randomUUID()
+      uuid: typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : nodeRandomUUID()
     };
 
     this.queue.push({ event, payload: body.properties });


### PR DESCRIPTION
## Summary
- mark the analytics helper as server-only and stop importing crypto via the unsupported `node:` scheme
- fall back to the Node.js randomUUID helper when the Web Crypto API is unavailable

## Testing
- pnpm --filter @torvus/console build

------
https://chatgpt.com/codex/tasks/task_b_68d4d111fe4c832dbe2817e012ff8693