### PR TITLE
refactor: centralize route role requirements

### DIFF
--- a/apps/console/app/(app)/security/events/page.tsx
+++ b/apps/console/app/(app)/security/events/page.tsx
@@ -1,2 +1,10 @@
+import AuditPage from '../../audit/page';
+import { withRequiredRole } from '../../../lib/with-authz';
+
 export { metadata } from '../../audit/page';
-export { default } from '../../audit/page';
+
+type AuditPageProps = Parameters<typeof AuditPage>[0];
+
+export default function SecurityEventsPage(props: AuditPageProps) {
+  return withRequiredRole(['security_admin', 'auditor'], () => AuditPage(props));
+}

--- a/apps/console/lib/with-authz.tsx
+++ b/apps/console/lib/with-authz.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { getIdentityFromRequestHeaders, getStaffUser } from './auth';
+import { requireRole } from './authz/gate';
+
+export async function withRequiredRole<T>(
+  allowed: Array<'security_admin' | 'auditor'>,
+  render: (ctx: { email: string; roles: string[] }) => Promise<T> | T
+): Promise<T | ReactNode> {
+  const { email } = getIdentityFromRequestHeaders();
+  if (!email) {
+    return redirect('/access-denied?reason=missing_email');
+  }
+
+  const staffUser = await getStaffUser();
+  if (!staffUser) {
+    return redirect('/access-denied?reason=not_enrolled');
+  }
+
+  if (!requireRole(staffUser.roles, allowed)) {
+    return redirect('/access-denied?reason=insufficient_role');
+  }
+
+  return render({ email, roles: staffUser.roles });
+}


### PR DESCRIPTION
## Summary
- add a reusable requireRole helper and server component wrapper for role-guarded routes
- refactor overview, admin staff, roles, and security events pages to rely on the declarative wrapper
- clean up redundant denied panel handling and keep consistent error callouts for fetch failures

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68d53d273518832d95c0312afe42b78b