### PR TITLE
feat: wire up personal token management

### DIFF
--- a/apps/console/app/(app)/api/tokens/[id]/route.ts
+++ b/apps/console/app/(app)/api/tokens/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { revokePat } from '../../../../../server/pat';
+import { resolveTokenActor } from '../_helpers';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id?: string;
+  };
+};
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const resolution = await resolveTokenActor(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  const tokenId = context.params.id;
+  if (!tokenId) {
+    return new Response('not found', { status: 404 });
+  }
+
+  try {
+    const row = await revokePat(tokenId, resolution.userId);
+    if (!row) {
+      return new Response('not found', { status: 404 });
+    }
+
+    return NextResponse.json(row, { headers: { 'cache-control': 'no-store' } });
+  } catch (error) {
+    console.error('failed to revoke personal access token', { tokenId, error });
+    return new Response('failed to revoke personal access token', { status: 500 });
+  }
+}

--- a/apps/console/app/(app)/api/tokens/_helpers.ts
+++ b/apps/console/app/(app)/api/tokens/_helpers.ts
@@ -1,0 +1,48 @@
+import { getIdentityFromRequestHeaders, getStaffUserByEmail } from '../../../../lib/auth';
+import {
+  SupabaseConfigurationError,
+  createSupabaseServiceRoleClient
+} from '../../../../lib/supabase';
+
+type ResolutionSuccess = {
+  ok: true;
+  userId: string;
+  email: string;
+};
+
+type ResolutionFailure = {
+  ok: false;
+  response: Response;
+};
+
+export async function resolveTokenActor(request: Request): Promise<ResolutionSuccess | ResolutionFailure> {
+  const { email } = getIdentityFromRequestHeaders(request.headers);
+
+  if (!email) {
+    return { ok: false, response: new Response('unauthorized', { status: 401 }) };
+  }
+
+  let supabase;
+  try {
+    supabase = createSupabaseServiceRoleClient();
+  } catch (error) {
+    if (error instanceof SupabaseConfigurationError) {
+      console.error('personal token handling unavailable: Supabase not configured', error);
+      return { ok: false, response: new Response('service unavailable', { status: 503 }) };
+    }
+
+    throw error;
+  }
+
+  try {
+    const staffUser = await getStaffUserByEmail(email, supabase);
+    if (!staffUser || !staffUser.user_id) {
+      return { ok: false, response: new Response('forbidden', { status: 403 }) };
+    }
+
+    return { ok: true, userId: staffUser.user_id, email };
+  } catch (error) {
+    console.error('failed to resolve staff user for personal tokens', error);
+    return { ok: false, response: new Response('failed to resolve staff user', { status: 500 }) };
+  }
+}

--- a/apps/console/app/(app)/api/tokens/route.ts
+++ b/apps/console/app/(app)/api/tokens/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { createPat, listPats } from '../../../../server/pat';
+import { resolveTokenActor } from './_helpers';
+
+export const dynamic = 'force-dynamic';
+
+type CreateTokenPayload = {
+  name?: unknown;
+  scopes?: unknown;
+  expires_at?: unknown;
+};
+
+function parseScopes(value: unknown): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('scopes must be an array');
+  }
+
+  const filtered = value.filter((scope): scope is string => typeof scope === 'string' && scope.trim().length > 0);
+  return filtered.length ? filtered : [];
+}
+
+function parseExpiry(value: unknown): Date | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null || value === '') {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error('expires_at must be an ISO timestamp string');
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new Error('expires_at must be a valid ISO timestamp');
+  }
+
+  return new Date(timestamp);
+}
+
+export async function GET(request: Request) {
+  const resolution = await resolveTokenActor(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  try {
+    const tokens = await listPats(resolution.userId);
+    return NextResponse.json(tokens, { headers: { 'cache-control': 'no-store' } });
+  } catch (error) {
+    console.error('failed to list personal access tokens', error);
+    return new Response('failed to list personal access tokens', { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const resolution = await resolveTokenActor(request);
+  if (!resolution.ok) {
+    return resolution.response;
+  }
+
+  let payload: CreateTokenPayload;
+  try {
+    payload = (await request.json()) as CreateTokenPayload;
+  } catch (error) {
+    console.error('invalid JSON payload for personal access token creation', error);
+    return new Response('invalid JSON payload', { status: 400 });
+  }
+
+  const rawName = typeof payload.name === 'string' ? payload.name.trim() : '';
+  if (!rawName) {
+    return new Response('name is required', { status: 400 });
+  }
+
+  let scopes: string[] | undefined;
+  try {
+    scopes = parseScopes(payload.scopes);
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : 'invalid scopes', { status: 400 });
+  }
+
+  let expiresAt: Date | null | undefined;
+  try {
+    expiresAt = parseExpiry(payload.expires_at);
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : 'invalid expires_at', { status: 400 });
+  }
+
+  try {
+    const result = await createPat(resolution.userId, rawName, scopes, expiresAt ?? undefined);
+    return NextResponse.json(result, {
+      status: 201,
+      headers: { 'cache-control': 'no-store' }
+    });
+  } catch (error) {
+    console.error('failed to create personal access token', error);
+    return new Response('failed to create personal access token', { status: 500 });
+  }
+}

--- a/apps/console/app/(app)/profile/PersonalAccessTokensPanel.tsx
+++ b/apps/console/app/(app)/profile/PersonalAccessTokensPanel.tsx
@@ -164,7 +164,7 @@ export const PersonalAccessTokensPanel = forwardRef<
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/self/pats', { cache: 'no-store' });
+      const response = await fetch('/app/api/tokens', { cache: 'no-store' });
       if (!response.ok) {
         const message = await response.text();
         throw new Error(message || 'failed to load tokens');
@@ -255,7 +255,7 @@ export const PersonalAccessTokensPanel = forwardRef<
       }
 
       try {
-        const response = await fetch('/api/self/pats', {
+        const response = await fetch('/app/api/tokens', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -288,7 +288,7 @@ export const PersonalAccessTokensPanel = forwardRef<
   const handleRevoke = useCallback(async (id: string) => {
     try {
       setError(null);
-      const response = await fetch(`/api/self/pats/${encodeURIComponent(id)}/revoke`, { method: 'POST' });
+      const response = await fetch(`/app/api/tokens/${encodeURIComponent(id)}`, { method: 'DELETE' });
       if (!response.ok) {
         const message = await response.text();
         throw new Error(message || 'failed to revoke token');
@@ -438,6 +438,13 @@ export const PersonalAccessTokensPanel = forwardRef<
                   Tokens are scoped to your account. Store the generated secret securely — it cannot be recovered later.
                 </p>
               </div>
+
+              <Callout.Root color="iris" role="note">
+                <Callout.Text>
+                  Tokens inherit your current staff roles at the moment they are created. If your access changes in the future,
+                  generate a new token to pick up updated permissions.
+                </Callout.Text>
+              </Callout.Root>
 
               <label className="flex flex-col gap-2 text-sm text-slate-200">
                 <span className="font-semibold">Name</span>

--- a/apps/console/server/pat.ts
+++ b/apps/console/server/pat.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes } from 'crypto';
 import { createSupabaseServiceRoleClient } from '../lib/supabase';
 
-const TOKEN_PREFIX = 'torv_pat_';
 const TOKEN_BYTE_LENGTH = 32;
 
 export type PersonalAccessTokenRow = {
@@ -41,7 +40,7 @@ export async function createPat(
 ): Promise<{ token: string; row: PersonalAccessTokenRow }> {
   const supabase = createSupabaseServiceRoleClient();
   const tokenBytes = randomBytes(TOKEN_BYTE_LENGTH);
-  const tokenSecret = `${TOKEN_PREFIX}${tokenBytes.toString('base64url')}`;
+  const tokenSecret = tokenBytes.toString('hex');
   const tokenHash = hashToken(tokenSecret);
   const payload: Record<string, unknown> = {
     user_id: userId,


### PR DESCRIPTION
## Summary
- add authenticated /app/api/tokens endpoints to list, create, and revoke personal access tokens
- generate 32-byte hexadecimal secrets when creating tokens
- update the personal access token panel to use the new API and surface role inheritance guidance

## Testing
- pnpm --filter @torvus/console lint

------
https://chatgpt.com/codex/tasks/task_b_68d5c428f41c832d85d574f5224cd329