### PR TITLE
Add environment preflight for staff Supabase auth

### DIFF
--- a/apps/console/app/api/staff/selftest/route.ts
+++ b/apps/console/app/api/staff/selftest/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from '../../../../lib/auth/staff';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false
+    }
+  });
+
+  try {
+    const { error } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1 });
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[api:staff:selftest] Supabase self-test failed', error);
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unexpected error running Supabase self-test';
+    return NextResponse.json({ ok: false, error: errorMessage }, { status: 500 });
+  }
+}

--- a/apps/console/app/api/staff/selftest/route.ts
+++ b/apps/console/app/api/staff/selftest/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from '../../../../lib/auth/staff';
+import { SUPABASE_SERVICE_ROLE, SUPABASE_URL } from '../../../../lib/auth/staff';
 
 export const runtime = 'nodejs';
 
 export async function GET() {
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
     auth: {
       autoRefreshToken: false,
       persistSession: false

--- a/apps/console/lib/auth/staff.ts
+++ b/apps/console/lib/auth/staff.ts
@@ -1,11 +1,13 @@
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY as string | undefined;
+const rawSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const rawSupabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-if (!SUPABASE_URL?.startsWith("https://") || !SUPABASE_URL?.includes(".supabase.co")) {
-  throw new Error("NEXT_PUBLIC_SUPABASE_URL is invalid. Expect like https://XXXX.supabase.co");
-}
-if (!SUPABASE_SERVICE_ROLE_KEY || SUPABASE_SERVICE_ROLE_KEY.length < 40) {
-  throw new Error("SUPABASE_SERVICE_ROLE_KEY is missing or looks wrong.");
+if (!rawSupabaseUrl?.startsWith('https://') || !rawSupabaseUrl?.includes('.supabase.co')) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL is invalid. Expect like https://XXXX.supabase.co');
 }
 
-export { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL };
+if (!rawSupabaseServiceRoleKey || rawSupabaseServiceRoleKey.length < 40) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is missing or looks wrong.');
+}
+
+export const SUPABASE_URL = rawSupabaseUrl;
+export const SUPABASE_SERVICE_ROLE_KEY = rawSupabaseServiceRoleKey;

--- a/apps/console/lib/auth/staff.ts
+++ b/apps/console/lib/auth/staff.ts
@@ -1,0 +1,11 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY as string | undefined;
+
+if (!SUPABASE_URL?.startsWith("https://") || !SUPABASE_URL?.includes(".supabase.co")) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_URL is invalid. Expect like https://XXXX.supabase.co");
+}
+if (!SUPABASE_SERVICE_ROLE_KEY || SUPABASE_SERVICE_ROLE_KEY.length < 40) {
+  throw new Error("SUPABASE_SERVICE_ROLE_KEY is missing or looks wrong.");
+}
+
+export { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL };

--- a/apps/console/lib/auth/staff.ts
+++ b/apps/console/lib/auth/staff.ts
@@ -1,13 +1,13 @@
-const rawSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const rawSupabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const rawSupabaseUrl = process.env.SUPABASE_URL;
+const rawSupabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE;
 
 if (!rawSupabaseUrl?.startsWith('https://') || !rawSupabaseUrl?.includes('.supabase.co')) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_URL is invalid. Expect like https://XXXX.supabase.co');
+  throw new Error('SUPABASE_URL is invalid. Expect like https://XXXX.supabase.co');
 }
 
 if (!rawSupabaseServiceRoleKey || rawSupabaseServiceRoleKey.length < 40) {
-  throw new Error('SUPABASE_SERVICE_ROLE_KEY is missing or looks wrong.');
+  throw new Error('SUPABASE_SERVICE_ROLE is missing or looks wrong.');
 }
 
 export const SUPABASE_URL = rawSupabaseUrl;
-export const SUPABASE_SERVICE_ROLE_KEY = rawSupabaseServiceRoleKey;
+export const SUPABASE_SERVICE_ROLE = rawSupabaseServiceRoleKey;


### PR DESCRIPTION
## Summary
- add a preflight check in the staff auth helper to validate Supabase environment variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d60108c9f0832d88310ab015741e5d