### PR TITLE
Secure signing admin routes via RPC adapters

### DIFF
--- a/apps/console/app/(app)/admin/break-glass/page.tsx
+++ b/apps/console/app/(app)/admin/break-glass/page.tsx
@@ -4,7 +4,7 @@ import {
   type RoleOption,
   type StaffDirectoryEntry
 } from '../../../../components/admin/BreakGlassDashboard';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 import { loadAuthz } from '../../../(lib)/authz';
 import { DeniedPanel } from '../../../(lib)/denied-panel';
 

--- a/apps/console/app/(app)/admin/settings/page.tsx
+++ b/apps/console/app/(app)/admin/settings/page.tsx
@@ -1,5 +1,5 @@
 import { ReadOnlySettingsForm } from '../../../../components/admin/ReadOnlySettingsForm';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 import { getReadOnly } from '../../../../server/settings';
 import { loadAuthz, authorizeRoles } from '../../../(lib)/authz';
 import { DeniedPanel } from '../../../(lib)/denied-panel';

--- a/apps/console/app/(app)/api/tokens/_helpers.ts
+++ b/apps/console/app/(app)/api/tokens/_helpers.ts
@@ -1,8 +1,6 @@
 import { getIdentityFromRequestHeaders, getStaffUserByEmail } from '../../../../lib/auth';
-import {
-  SupabaseConfigurationError,
-  createSupabaseServiceRoleClient
-} from '../../../../lib/supabase';
+import { SupabaseConfigurationError } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 
 type ResolutionSuccess = {
   ok: true;

--- a/apps/console/app/(app)/audit-events/actions.ts
+++ b/apps/console/app/(app)/audit-events/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { requireStaff } from '../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
 import { getAnalyticsClient } from '../../../lib/analytics';
 import { FilterSchema, FilterValues, AuditEventRow } from './shared';
 

--- a/apps/console/app/(app)/audit-events/page.tsx
+++ b/apps/console/app/(app)/audit-events/page.tsx
@@ -1,6 +1,6 @@
 import { headers } from 'next/headers';
 import { requireStaff } from '../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
 import { getAnalyticsClient } from '../../../lib/analytics';
 import { PageHeader } from '../../../components/PageHeader';
 import { exportAuditCsv, exportAuditJson } from './actions';

--- a/apps/console/app/(app)/profile/page.tsx
+++ b/apps/console/app/(app)/profile/page.tsx
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { Box, Button, Text } from '@radix-ui/themes';
 import { ProfileForm, type ProfileFormState } from './ProfileForm';
 import { getStaffUser } from '../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
 import { PersonalAccessTokensPanel } from './PersonalAccessTokensPanel';
 import { enforceNotReadOnly, isReadOnlyError } from '../../../server/guard';
 import { PageHeader } from '../../../components/navigation/page-header';

--- a/apps/console/app/(lib)/authz.ts
+++ b/apps/console/app/(lib)/authz.ts
@@ -1,9 +1,5 @@
-import {
-  SupabaseConfigurationError,
-  createSupabaseServiceRoleClient,
-  isSupabaseConfigured,
-  isTransientSupabaseError
-} from '../../lib/supabase';
+import { SupabaseConfigurationError, isSupabaseConfigured, isTransientSupabaseError } from '../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../lib/supabase/admin';
 import { getSessionUser } from '../../lib/auth';
 import { normaliseStaffEmail } from '../../lib/auth/email';
 import { getDevStaffConfig } from '../../lib/devStaff';

--- a/apps/console/app/api/admin/integrations/_helpers.ts
+++ b/apps/console/app/api/admin/integrations/_helpers.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 
 export type AdminContext = {
   supabase: SupabaseClient<any>;

--- a/apps/console/app/api/admin/people/route.ts
+++ b/apps/console/app/api/admin/people/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/console/app/api/admin/roles/assign/route.ts
+++ b/apps/console/app/api/admin/roles/assign/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { logAudit } from '../../../../../server/audit';
 
 function hasSecurityAdminRole(roles: string[]): boolean {

--- a/apps/console/app/api/admin/roles/route.ts
+++ b/apps/console/app/api/admin/roles/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/console/app/api/admin/roles/unassign/route.ts
+++ b/apps/console/app/api/admin/roles/unassign/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { logAudit } from '../../../../../server/audit';
 
 function hasSecurityAdminRole(roles: string[]): boolean {

--- a/apps/console/app/api/admin/settings/read-only/route.ts
+++ b/apps/console/app/api/admin/settings/read-only/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getIdentityFromRequestHeaders, getUserRolesByEmail, getStaffUserByEmail } from '../../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { getReadOnly, setReadOnly } from '../../../../../server/settings';
 
 export const dynamic = 'force-dynamic';

--- a/apps/console/app/api/admin/signing/jobs/[id]/route.ts
+++ b/apps/console/app/api/admin/signing/jobs/[id]/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../../../lib/supabase/admin';
+import { getSigningJob } from '../../../../../../lib/rpc/signing';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export async function GET(
+  request: Request,
+  context: { params: { id?: string } }
+): Promise<Response> {
+  const jobId = context.params.id;
+  if (!jobId) {
+    return new Response('missing job id', { status: 400 });
+  }
+
+  const { email } = getIdentityFromRequestHeaders(request.headers);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let roles: string[];
+  try {
+    roles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('[api:admin:signing:job] failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  try {
+    const job = await getSigningJob(jobId);
+    if (!job) {
+      return new Response('not found', { status: 404 });
+    }
+
+    return NextResponse.json(job);
+  } catch (error) {
+    console.error('[api:admin:signing:job] failed to load signing job', error);
+    return new Response('failed to load signing job', { status: 500 });
+  }
+}

--- a/apps/console/app/api/admin/signing/jobs/route.ts
+++ b/apps/console/app/api/admin/signing/jobs/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
+import { listSigningJobs } from '../../../../../lib/rpc/signing';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+function parseLimitParam(rawLimit: string | null): number | undefined {
+  if (rawLimit === null || rawLimit.trim() === '') {
+    return undefined;
+  }
+
+  const parsed = Number(rawLimit);
+  if (Number.isNaN(parsed)) {
+    throw new Error('invalid limit');
+  }
+
+  return parsed;
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { email } = getIdentityFromRequestHeaders(request.headers);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let roles: string[];
+  try {
+    roles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('[api:admin:signing:jobs] failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  const url = new URL(request.url);
+
+  let limit: number | undefined;
+  try {
+    limit = parseLimitParam(url.searchParams.get('limit'));
+  } catch (error) {
+    return new Response('invalid limit', { status: 400 });
+  }
+
+  const cursorParam = url.searchParams.get('cursor') ?? undefined;
+
+  try {
+    const result = await listSigningJobs({ limit, cursor: cursorParam ?? undefined });
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Invalid signing job cursor')) {
+      return new Response(error.message, { status: 400 });
+    }
+
+    console.error('[api:admin:signing:jobs] failed to list signing jobs', error);
+    return new Response('failed to list signing jobs', { status: 500 });
+  }
+}

--- a/apps/console/app/api/admin/signing/receipts/[id]/route.ts
+++ b/apps/console/app/api/admin/signing/receipts/[id]/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+import { getIdentityFromRequestHeaders, getUserRolesByEmail } from '../../../../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../../../../lib/supabase/admin';
+import { getSigningReceipt } from '../../../../../../lib/rpc/signing';
+
+export const dynamic = 'force-dynamic';
+
+function hasSecurityAdminRole(roles: string[]): boolean {
+  return roles.some((role) => role.toLowerCase() === 'security_admin');
+}
+
+export async function GET(
+  request: Request,
+  context: { params: { id?: string } }
+): Promise<Response> {
+  const receiptId = context.params.id;
+  if (!receiptId) {
+    return new Response('missing receipt id', { status: 400 });
+  }
+
+  const { email } = getIdentityFromRequestHeaders(request.headers);
+  if (!email) {
+    return new Response('unauthorized', { status: 401 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+
+  let roles: string[];
+  try {
+    roles = await getUserRolesByEmail(email, supabase);
+  } catch (error) {
+    console.error('[api:admin:signing:receipt] failed to resolve requester roles', error);
+    return new Response('failed to resolve roles', { status: 500 });
+  }
+
+  if (!hasSecurityAdminRole(roles)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  try {
+    const receipt = await getSigningReceipt(receiptId);
+    if (!receipt) {
+      return new Response('not found', { status: 404 });
+    }
+
+    return NextResponse.json(receipt);
+  } catch (error) {
+    console.error('[api:admin:signing:receipt] failed to load signing receipt', error);
+    return new Response('failed to load signing receipt', { status: 500 });
+  }
+}

--- a/apps/console/app/api/breakglass/requests/route.ts
+++ b/apps/console/app/api/breakglass/requests/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSelf } from '../../../../lib/self';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 import { hasRoleAt } from '../../../../server/roles';
 import { createRequest } from '../../../../server/breakglass';
 

--- a/apps/console/app/api/investigations/utils.ts
+++ b/apps/console/app/api/investigations/utils.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
 import {
   getIdentityFromRequestHeaders,
   getStaffUserByEmail,

--- a/apps/console/app/api/releases/utils.ts
+++ b/apps/console/app/api/releases/utils.ts
@@ -5,7 +5,7 @@ import {
   getUserRolesByEmail,
   type StaffUserRecord
 } from '../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
 
 type ViewerOk = {
   type: 'ok';

--- a/apps/console/app/api/secrets/reveal/route.ts
+++ b/apps/console/app/api/secrets/reveal/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireStaff } from '../../../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 import { consumeReveal, getDecrypted, maskSecretTail } from '../../../../server/secrets';
 
 const RevealSchema = z.object({

--- a/apps/console/app/api/selfcheck/route.ts
+++ b/apps/console/app/api/selfcheck/route.ts
@@ -103,23 +103,3 @@ export async function GET(request: Request) {
     });
   }
 }
-
-
-// apps/console/app/api/staff/selftest/route.ts
-export const runtime = "nodejs";
-
-import { NextResponse } from "next/server";
-import { getStaffRolesForCurrentUser } from "@/lib/auth/staff";
-
-export async function GET() {
-  try {
-    const { email, roles } = await getStaffRolesForCurrentUser();
-    return NextResponse.json({ ok: true, email, roles });
-  } catch (err: any) {
-    // expose details so we can see what's failing
-    return NextResponse.json(
-      { ok: false, error: err?.message ?? String(err) },
-      { status: 500 }
-    );
-  }
-}

--- a/apps/console/app/api/staff/dual-control/approve/route.ts
+++ b/apps/console/app/api/staff/dual-control/approve/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { requireStaff } from '../../../../../lib/auth';
 import { getAnalyticsClient } from '../../../../../lib/analytics';
 import type { DualControlRequestRow } from '../types';

--- a/apps/console/app/api/staff/dual-control/execute/route.ts
+++ b/apps/console/app/api/staff/dual-control/execute/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { requireStaff } from '../../../../../lib/auth';
 import { getAnalyticsClient } from '../../../../../lib/analytics';
 import type { PermissionKey } from '../../../../../lib/rbac';

--- a/apps/console/app/api/staff/dual-control/request/route.ts
+++ b/apps/console/app/api/staff/dual-control/request/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../../../../lib/supabase/admin';
 import { requireStaff } from '../../../../../lib/auth';
 import { getAnalyticsClient } from '../../../../../lib/analytics';
 import type { PermissionKey } from '../../../../../lib/rbac';

--- a/apps/console/app/api/staff/selftest/route.ts
+++ b/apps/console/app/api/staff/selftest/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
 import { listSigningJobs } from '../../../../lib/rpc/signing';
 
@@ -12,7 +14,7 @@ type TableCheckResult = {
 };
 
 async function verifyTableReadBlocked(
-  supabase: ReturnType<typeof createSupabaseServiceRoleClient>,
+  supabase: SupabaseClient,
   table: string
 ): Promise<TableCheckResult> {
   const { error } = (await (supabase.from(table) as any).select('id').limit(1)) as {

--- a/apps/console/app/api/staff/selftest/route.ts
+++ b/apps/console/app/api/staff/selftest/route.ts
@@ -1,29 +1,85 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_SERVICE_ROLE, SUPABASE_URL } from '../../../../lib/auth/staff';
+
+import { createSupabaseServiceRoleClient } from '../../../../lib/supabase/admin';
+import { listSigningJobs } from '../../../../lib/rpc/signing';
 
 export const runtime = 'nodejs';
 
+type TableCheckResult = {
+  table: string;
+  blocked: boolean;
+  error?: string;
+};
+
+async function verifyTableReadBlocked(
+  supabase: ReturnType<typeof createSupabaseServiceRoleClient>,
+  table: string
+): Promise<TableCheckResult> {
+  const { error } = (await (supabase.from(table) as any).select('id').limit(1)) as {
+    error: { message?: string } | null;
+  };
+
+  if (error) {
+    return { table, blocked: true, error: error.message };
+  }
+
+  return { table, blocked: false };
+}
+
 export async function GET() {
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  });
+  const supabase = createSupabaseServiceRoleClient();
 
   try {
     const { error } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1 });
-
     if (error) {
       throw error;
     }
-
-    return NextResponse.json({ ok: true });
   } catch (error) {
-    console.error('[api:staff:selftest] Supabase self-test failed', error);
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unexpected error running Supabase self-test';
-    return NextResponse.json({ ok: false, error: errorMessage }, { status: 500 });
+    console.error('[api:staff:selftest] Supabase admin API check failed', error);
+    const message =
+      error instanceof Error ? error.message : 'Unexpected error running Supabase admin self-test';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
+
+  try {
+    await listSigningJobs({ limit: 1 });
+  } catch (error) {
+    console.error('[api:staff:selftest] Signing RPC health check failed', error);
+    const message =
+      error instanceof Error ? error.message : 'Unexpected error invoking signing RPC endpoint';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+
+  const tableChecks = await Promise.all([
+    verifyTableReadBlocked(supabase, 'signing_jobs'),
+    verifyTableReadBlocked(supabase, 'signing_receipts')
+  ]);
+
+  const directReadAllowed = tableChecks.filter((check) => !check.blocked);
+
+  if (directReadAllowed.length > 0) {
+    console.error('[api:staff:selftest] Direct signing table read unexpectedly succeeded', {
+      tables: directReadAllowed.map((check) => check.table)
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Direct signing table read unexpectedly succeeded',
+        tables: directReadAllowed.map((check) => check.table)
+      },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    supabase: {
+      adminListUsers: true
+    },
+    signing: {
+      rpcHealthy: true,
+      directTableReadsBlocked: true,
+      checks: tableChecks
+    }
+  });
 }

--- a/apps/console/app/enroll-passkey/actions.ts
+++ b/apps/console/app/enroll-passkey/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
 import { requireStaff } from '../../lib/auth';
-import { createSupabaseServiceRoleClient } from '../../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../../lib/supabase/admin';
 import { getAnalyticsClient } from '../../lib/analytics';
 import type { EnrollmentState } from './types';
 

--- a/apps/console/lib/auth.ts
+++ b/apps/console/lib/auth.ts
@@ -1,11 +1,11 @@
 import { headers } from 'next/headers';
 import {
   createSupabaseServerClient,
-  createSupabaseServiceRoleClient,
   SupabaseConfigurationError,
   isSupabaseConfigured,
   isTransientSupabaseError
 } from './supabase';
+import { createSupabaseServiceRoleClient } from './supabase/admin';
 import type { PermissionKey } from './rbac';
 import { expandPermissionsForRoles } from './rbac';
 import { anonymiseEmail } from './analytics';

--- a/apps/console/lib/authz/gate.ts
+++ b/apps/console/lib/authz/gate.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../supabase';
+import { createSupabaseServiceRoleClient } from '../supabase/admin';
 import type { PostgrestLikeOrSupabase } from '../types';
 import { normaliseStaffEmail } from '../auth/email';
 import { getDevStaffConfig } from '../devStaff';

--- a/apps/console/lib/data/alerts.ts
+++ b/apps/console/lib/data/alerts.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../supabase';
+import { createSupabaseServiceRoleClient } from '../supabase/admin';
 
 type AlertRow = {
   id: string;

--- a/apps/console/lib/data/investigations.ts
+++ b/apps/console/lib/data/investigations.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../supabase';
+import { createSupabaseServiceRoleClient } from '../supabase/admin';
 import {
   INVESTIGATION_SEVERITIES,
   INVESTIGATION_STATUSES,

--- a/apps/console/lib/data/staff.ts
+++ b/apps/console/lib/data/staff.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../supabase';
+import { createSupabaseServiceRoleClient } from '../supabase/admin';
 import { normaliseStaffEmail } from '../auth/email';
 
 export type StaffDirectoryEntry = {

--- a/apps/console/lib/rpc/signing.ts
+++ b/apps/console/lib/rpc/signing.ts
@@ -1,0 +1,142 @@
+import 'server-only';
+
+import { createSupabaseServiceRoleClient } from '../supabase/admin';
+import {
+  SigningJobRecordSchema,
+  SigningReceiptRecordSchema,
+  type SigningJobRecord,
+  type SigningReceiptRecord
+} from '../../types/internal/signing';
+
+export type SigningJob = {
+  id: string;
+  ownerId: string | null;
+  status: string | null;
+  createdAt: string;
+  job: unknown;
+};
+
+export type SigningReceipt = {
+  id: string;
+  ownerId: string | null;
+  createdAt: string;
+  receipt: unknown;
+};
+
+export type SigningJobListOptions = {
+  limit?: number;
+  cursor?: string;
+};
+
+export type SigningJobListResult = {
+  jobs: SigningJob[];
+  nextCursor: string | null;
+};
+
+function clampLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit ?? Number.NaN)) {
+    return 50;
+  }
+
+  const bounded = Math.max(1, Math.min(200, Math.floor(limit!)));
+  return bounded;
+}
+
+function normaliseCursor(cursor: string | undefined): string | null {
+  if (!cursor) {
+    return null;
+  }
+
+  const parsed = new Date(cursor);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid signing job cursor. Expected ISO-8601 timestamp.');
+  }
+
+  return parsed.toISOString();
+}
+
+function normaliseTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid timestamp returned from signing RPC.');
+  }
+  return parsed.toISOString();
+}
+
+function toSigningJob(record: SigningJobRecord): SigningJob {
+  return {
+    id: record.id,
+    ownerId: record.owner_id ?? null,
+    status: record.status ?? null,
+    createdAt: normaliseTimestamp(record.created_at),
+    job: record.job ?? null
+  };
+}
+
+function toSigningReceipt(record: SigningReceiptRecord): SigningReceipt {
+  return {
+    id: record.id,
+    ownerId: record.owner_id ?? null,
+    createdAt: normaliseTimestamp(record.created_at),
+    receipt: record.receipt ?? null
+  };
+}
+
+export async function getSigningJob(id: string): Promise<SigningJob | null> {
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await supabase.rpc('signing_job_get', { p_id: id });
+
+  if (error) {
+    throw new Error(`Failed to load signing job ${id}: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const record = SigningJobRecordSchema.parse(data);
+  return toSigningJob(record);
+}
+
+export async function getSigningReceipt(id: string): Promise<SigningReceipt | null> {
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await supabase.rpc('signing_receipt_read', { p_id: id });
+
+  if (error) {
+    throw new Error(`Failed to load signing receipt ${id}: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const record = SigningReceiptRecordSchema.parse(data);
+  return toSigningReceipt(record);
+}
+
+export async function listSigningJobs(
+  options: SigningJobListOptions = {}
+): Promise<SigningJobListResult> {
+  const limit = clampLimit(options.limit);
+  const cursor = normaliseCursor(options.cursor);
+
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await supabase.rpc('signing_jobs_list', {
+    p_limit: limit,
+    p_after: cursor
+  });
+
+  if (error) {
+    throw new Error(`Failed to list signing jobs: ${error.message}`);
+  }
+
+  const rows = Array.isArray(data) ? data : [];
+  const jobs = rows.map((row) => toSigningJob(SigningJobRecordSchema.parse(row)));
+
+  const nextCursor = jobs.length === limit ? jobs[jobs.length - 1]?.createdAt ?? null : null;
+
+  return {
+    jobs,
+    nextCursor
+  };
+}

--- a/apps/console/lib/self.ts
+++ b/apps/console/lib/self.ts
@@ -1,5 +1,5 @@
 import { getIdentityFromRequestHeaders } from './auth';
-import { createSupabaseServiceRoleClient } from './supabase';
+import { createSupabaseServiceRoleClient } from './supabase/admin';
 import { evaluateAccessGate } from './authz/gate';
 
 export type SelfProfile = {

--- a/apps/console/lib/supabase/admin.ts
+++ b/apps/console/lib/supabase/admin.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import { SupabaseConfigurationError, getSupabaseConfig, type Database } from './index';
+
+const requiredEnv = ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE'] as const;
+
+function assertAdminEnv() {
+  const missing = requiredEnv.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new SupabaseConfigurationError(missing);
+  }
+}
+
+let serviceRoleClient: SupabaseClient<Database> | null = null;
+
+export function createSupabaseServiceRoleClient<TDatabase = Database>(): SupabaseClient<TDatabase> {
+  assertAdminEnv();
+
+  if (!serviceRoleClient) {
+    const { url, serviceRoleKey } = getSupabaseConfig();
+    serviceRoleClient = createClient<Database>(url, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false
+      }
+    });
+  }
+
+  return serviceRoleClient as SupabaseClient<TDatabase>;
+}

--- a/apps/console/lib/supabase/index.ts
+++ b/apps/console/lib/supabase/index.ts
@@ -1,4 +1,3 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 
@@ -66,23 +65,6 @@ export function createSupabaseServerClient<TDatabase = Database>() {
     supabaseUrl: process.env.SUPABASE_URL!,
     supabaseKey: process.env.SUPABASE_ANON_KEY!
   });
-}
-
-let serviceRoleClient: SupabaseClient<Database> | null = null;
-
-export function createSupabaseServiceRoleClient<TDatabase = Database>(): SupabaseClient<TDatabase> {
-  assertEnv();
-
-  if (!serviceRoleClient) {
-    serviceRoleClient = createClient<Database>(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!, {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false
-      }
-    });
-  }
-
-  return serviceRoleClient as SupabaseClient<TDatabase>;
 }
 
 export function getSupabaseConfig() {

--- a/apps/console/lib/supabase/index.ts
+++ b/apps/console/lib/supabase/index.ts
@@ -1,6 +1,8 @@
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 
+import type { SigningJobRecord, SigningReceiptRecord } from '../../types/internal/signing';
+
 const requiredEnv = ['SUPABASE_URL', 'SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE'] as const;
 
 export class SupabaseConfigurationError extends Error {
@@ -57,7 +59,28 @@ function assertEnv() {
   }
 }
 
-export type Database = Record<string, never>; // Placeholder until Database types are generated
+export type Database = {
+  public: {
+    Tables: Record<string, never>;
+    Views: Record<string, never>;
+    Functions: {
+      signing_job_get: {
+        Args: { p_id: string };
+        Returns: SigningJobRecord | null;
+      };
+      signing_receipt_read: {
+        Args: { p_id: string };
+        Returns: SigningReceiptRecord | null;
+      };
+      signing_jobs_list: {
+        Args: { p_limit: number; p_after: string | null };
+        Returns: SigningJobRecord[];
+      };
+    };
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
 
 export function createSupabaseServerClient<TDatabase = Database>() {
   assertEnv();

--- a/apps/console/server/audit-data.ts
+++ b/apps/console/server/audit-data.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 
 export type AuditEventRow = {
   id: string;

--- a/apps/console/server/audit.ts
+++ b/apps/console/server/audit.ts
@@ -1,6 +1,6 @@
 import { headers as nextHeaders } from 'next/headers';
 import type { NextRequest } from 'next/server';
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import {
   getIdentityFromRequestHeaders,
   getSessionUser,

--- a/apps/console/server/breakglass.ts
+++ b/apps/console/server/breakglass.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import { logAudit } from './audit';
 import { grantTemporaryRoles } from './roles';
 

--- a/apps/console/server/entitlements.ts
+++ b/apps/console/server/entitlements.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import { logAudit } from './audit';
 
 const PLAN_KEY_VALUES = ['free', 'standard', 'journalist'] as const;

--- a/apps/console/server/intake.ts
+++ b/apps/console/server/intake.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto';
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import { logAudit, type RequestLike } from './audit';
 import { sendEvent } from './notify';
 import { INVESTIGATION_SEVERITIES, type InvestigationSeverity } from '../lib/investigations/constants';

--- a/apps/console/server/notify.ts
+++ b/apps/console/server/notify.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import { getDecrypted } from './secrets';
 
 type WebhookKind = 'slack' | 'teams';

--- a/apps/console/server/pat.ts
+++ b/apps/console/server/pat.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'crypto';
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 
 const TOKEN_BYTE_LENGTH = 32;
 

--- a/apps/console/server/roles.ts
+++ b/apps/console/server/roles.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 
 function normaliseRoleNames(roleNames: string[]): string[] {
   const normalised = new Set<string>();

--- a/apps/console/server/secrets.ts
+++ b/apps/console/server/secrets.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 import { encrypt, decrypt } from './crypto';
 import { logAudit } from './audit';
 

--- a/apps/console/server/settings.ts
+++ b/apps/console/server/settings.ts
@@ -1,4 +1,4 @@
-import { createSupabaseServiceRoleClient } from '../lib/supabase';
+import { createSupabaseServiceRoleClient } from '../lib/supabase/admin';
 
 export type ReadOnlySettings = {
   enabled: boolean;

--- a/apps/console/tests/api/admin/signing.test.ts
+++ b/apps/console/tests/api/admin/signing.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const modulePaths = vi.hoisted(() => ({
+  auth: new URL('../../../lib/auth.ts', import.meta.url).pathname,
+  supabaseAdmin: new URL('../../../lib/supabase/admin.ts', import.meta.url).pathname,
+  signingRpc: new URL('../../../lib/rpc/signing.ts', import.meta.url).pathname
+}));
+
+vi.mock(modulePaths.auth, () => ({
+  getIdentityFromRequestHeaders: vi.fn(() => ({ email: 'user@example.com', source: 'cloudflare' })),
+  getUserRolesByEmail: vi.fn(async () => [])
+}));
+
+vi.mock(modulePaths.supabaseAdmin, () => ({
+  createSupabaseServiceRoleClient: vi.fn(() => ({}))
+}));
+
+vi.mock(modulePaths.signingRpc, () => ({
+  getSigningJob: vi.fn(),
+  getSigningReceipt: vi.fn(),
+  listSigningJobs: vi.fn()
+}));
+
+import { getUserRolesByEmail } from '../../../lib/auth';
+import { createSupabaseServiceRoleClient } from '../../../lib/supabase/admin';
+import { getSigningJob, getSigningReceipt, listSigningJobs } from '../../../lib/rpc/signing';
+import * as jobDetailRoute from '../../../app/api/admin/signing/jobs/[id]/route';
+import * as jobListRoute from '../../../app/api/admin/signing/jobs/route';
+import * as receiptRoute from '../../../app/api/admin/signing/receipts/[id]/route';
+
+const getUserRolesByEmailMock = vi.mocked(getUserRolesByEmail);
+const createSupabaseServiceRoleClientMock = vi.mocked(createSupabaseServiceRoleClient);
+const getSigningJobMock = vi.mocked(getSigningJob);
+const listSigningJobsMock = vi.mocked(listSigningJobs);
+const getSigningReceiptMock = vi.mocked(getSigningReceipt);
+
+describe('admin signing routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserRolesByEmailMock.mockResolvedValue([]);
+  });
+
+  it('returns 403 for non-staff signing job detail requests', async () => {
+    const response = await jobDetailRoute.GET(
+      new Request('https://example.com/api/admin/signing/jobs/job-1'),
+      { params: { id: 'job-1' } }
+    );
+
+    expect(response.status).toBe(403);
+    expect(createSupabaseServiceRoleClientMock).toHaveBeenCalled();
+    expect(getUserRolesByEmailMock).toHaveBeenCalledWith('user@example.com', expect.any(Object));
+    expect(getSigningJobMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for non-staff signing job list requests', async () => {
+    const response = await jobListRoute.GET(
+      new Request('https://example.com/api/admin/signing/jobs')
+    );
+
+    expect(response.status).toBe(403);
+    expect(createSupabaseServiceRoleClientMock).toHaveBeenCalled();
+    expect(getUserRolesByEmailMock).toHaveBeenCalledWith('user@example.com', expect.any(Object));
+    expect(listSigningJobsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for non-staff signing receipt requests', async () => {
+    const response = await receiptRoute.GET(
+      new Request('https://example.com/api/admin/signing/receipts/receipt-1'),
+      { params: { id: 'receipt-1' } }
+    );
+
+    expect(response.status).toBe(403);
+    expect(createSupabaseServiceRoleClientMock).toHaveBeenCalled();
+    expect(getUserRolesByEmailMock).toHaveBeenCalledWith('user@example.com', expect.any(Object));
+    expect(getSigningReceiptMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/console/tests/setup.ts
+++ b/apps/console/tests/setup.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));

--- a/apps/console/types/internal/signing.ts
+++ b/apps/console/types/internal/signing.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const SigningJobRecordSchema = z.object({
+  id: z.string().uuid(),
+  owner_id: z.string().uuid().nullable().optional(),
+  job: z.unknown(),
+  status: z.string().nullable().optional(),
+  created_at: z.string()
+});
+
+export type SigningJobRecord = z.infer<typeof SigningJobRecordSchema>;
+
+export const SigningReceiptRecordSchema = z.object({
+  id: z.string().uuid(),
+  owner_id: z.string().uuid().nullable().optional(),
+  receipt: z.unknown(),
+  created_at: z.string()
+});
+
+export type SigningReceiptRecord = z.infer<typeof SigningReceiptRecordSchema>;

--- a/apps/console/vitest.config.ts
+++ b/apps/console/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['tests/setup.ts'],
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- add a server-only Supabase admin client and repoint service-role consumers
- introduce signing RPC helpers, DTOs, and staff admin API routes backed by the RPCs
- expand the staff self-test and add vitest coverage for the new admin signing endpoints

## Testing
- pnpm --filter @torvus/console lint
- pnpm --filter @torvus/console test

------
https://chatgpt.com/codex/tasks/task_b_68d7319d7078832d91df707bd73c7ed1